### PR TITLE
[KOGITO-9776] Make the workflow definition mount point to root path in devmode

### DIFF
--- a/controllers/profiles/reconciler_dev.go
+++ b/controllers/profiles/reconciler_dev.go
@@ -48,8 +48,6 @@ import (
 )
 
 const (
-	configMapWorkflowDefVolumeName             = "workflow-definition"
-	configMapWorkflowDefMountPath              = "/home/kogito/serverless-workflow-project/src/main/resources/workflows"
 	configMapResourcesVolumeName               = "resources"
 	configMapExternalResourcesVolumeNamePrefix = configMapResourcesVolumeName + "-"
 
@@ -354,13 +352,13 @@ func mountDevConfigMapsMutateVisitor(flowDefCM, propsCM *corev1.ConfigMap, workf
 
 			volumes := make([]corev1.Volume, 0)
 			volumeMounts := []corev1.VolumeMount{
-				kubeutil.VolumeMount(configMapWorkflowDefVolumeName, true, configMapWorkflowDefMountPath),
 				kubeutil.VolumeMount(configMapResourcesVolumeName, true, quarkusDevConfigMountPath),
 			}
 
 			// defaultResourcesVolume holds every ConfigMap mount required on src/main/resources
 			defaultResourcesVolume := corev1.Volume{Name: configMapResourcesVolumeName, VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{}}}
 			kubeutil.VolumeProjectionAddConfigMap(defaultResourcesVolume.Projected, propsCM.Name, corev1.KeyToPath{Key: workflowproj.ApplicationPropertiesFileName, Path: workflowproj.ApplicationPropertiesFileName})
+			kubeutil.VolumeProjectionAddConfigMap(defaultResourcesVolume.Projected, flowDefCM.Name)
 
 			// resourceVolumes holds every resource that needs to be mounted on src/main/resources/<specific_dir>
 			resourceVolumes := make([]corev1.Volume, 0)
@@ -378,7 +376,7 @@ func mountDevConfigMapsMutateVisitor(flowDefCM, propsCM *corev1.ConfigMap, workf
 				resourceVolumes = kubeutil.VolumeAddVolumeProjectionConfigMap(resourceVolumes, workflowResCM.ConfigMap.Name, volumeMountName)
 			}
 
-			volumes = append(volumes, defaultResourcesVolume, kubeutil.VolumeConfigMap(configMapWorkflowDefVolumeName, flowDefCM.Name))
+			volumes = append(volumes, defaultResourcesVolume)
 			volumes = append(volumes, resourceVolumes...)
 
 			deployment.Spec.Template.Spec.Volumes = make([]corev1.Volume, 0)

--- a/controllers/workflowdef/configmap.go
+++ b/controllers/workflowdef/configmap.go
@@ -43,8 +43,13 @@ func CreateNewConfigMap(workflow *operatorapi.SonataFlow) (*corev1.ConfigMap, er
 			Name:      workflow.Name,
 			Namespace: workflow.Namespace,
 		},
-		Data: map[string]string{workflow.Name + KogitoWorkflowJSONFileExt: string(workflowDef)},
+		Data: map[string]string{GetWorkflowDefFileName(workflow): string(workflowDef)},
 	}, nil
+}
+
+// GetWorkflowDefFileName returns the default workflow file definition that should be injected/mounted to a workflow application given a SonataFlow CR.
+func GetWorkflowDefFileName(workflow *operatorapi.SonataFlow) string {
+	return workflow.Name + KogitoWorkflowJSONFileExt
 }
 
 // FetchExternalResourcesConfigMapsRef fetches the Resource ConfigMaps into a LocalObjectReference that a client can mount to the workflow application.


### PR DESCRIPTION

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
In this PR, we do a small change when mounting the main flow definition to the devmode deployment. Now, the path is fixed to always mount in the root path.

**Motivation for the change:**
See: https://issues.redhat.com/browse/KOGITO-9776

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>