### PR TITLE
Fix #259 - Update GHA to follow Apache policies

### DIFF
--- a/.github/workflows/check-container-builder.yml
+++ b/.github/workflows/check-container-builder.yml
@@ -36,7 +36,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: make test
+      - run: |
+          cd container-builder
+          make test
 
   integration-tests:
     needs: unit-tests
@@ -59,12 +61,6 @@ jobs:
           libgpgme-dev \
           libbtrfs-dev \
           libdevmapper-dev
-      - name: Install Podman 4.3.1
-        run: |
-          wget http://security.ubuntu.com/ubuntu/pool/main/s/shadow/libsubid4_4.11.1+dfsg1-2ubuntu1.1_amd64.deb
-          sudo dpkg -i libsubid4_4.11.1+dfsg1-2ubuntu1.1_amd64.deb
-          wget http://ftp.us.debian.org/debian/pool/main/libp/libpod/podman_4.4.0+ds1-1_amd64.deb
-          sudo dpkg -i podman_4.4.0+ds1-1_amd64.deb
       - name: Setup golang
         uses: actions/setup-go@v2
         with:
@@ -73,20 +69,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Display Podman info
-        run: podman info
-      - name: Start Podman socket
-        run: |
-          systemctl --user start podman.socket
-          systemctl --user status podman.socket
       - name: Run integration tests
         run: |
-          mkdir -p ~/.config/systemd/user/podman.service.d/
-          printf "[Service]\nExecStart=\nExecStart=/usr/bin/podman $LOGGING system service -t 0\nDelegate=true\nType=exec\nKillMode=process\nEnvironment=LOGGING="--log-level=info"\n" > ~/.config/systemd/user/podman.service.d/override.conf
-          systemctl --user daemon-reload
-          systemctl --user start podman.service
-          pid=$(systemctl --user show podman.service  | grep ^MainPID | sed -e 's|MainPID=||')
-          sudo prlimit --pid $pid --nofile=262144:262144
-          sudo prlimit --pid $$ --nofile=262144:262144
           cd container-builder
           make ${{ matrix.container-engine }}-integration-test

--- a/.github/workflows/check-container-builder.yml
+++ b/.github/workflows/check-container-builder.yml
@@ -54,10 +54,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libbtrfs-dev libgpgme-dev libdevmapper-dev
-          version: 1.0
+        run: |
+          sudo apt-get -y install \
+          libgpgme-dev \
+          libbtrfs-dev \
+          libdevmapper-dev
       - name: Install Podman 4.3.1
         run: |
           wget http://security.ubuntu.com/ubuntu/pool/main/s/shadow/libsubid4_4.11.1+dfsg1-2ubuntu1.1_amd64.deb

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,10 +47,6 @@ jobs:
       - name: Run tests
         run: make test test-workflowproj
 
-      - uses: shogo82148/actions-goveralls@v1
-        with:
-          path-to-profile: cover.out
-
   check-headers:
     concurrency:
       group: sonataflow-operator-check-headers-${{ github.head_ref }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ env:
   # https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md
   # WARNING: kindest/node is not always existing with given version ...
   KUBERNETES_VERSION: v1.26.3
+  MINIKUBE_VERSION: v1.31.1
   DEBUG: true
 
 jobs:
@@ -48,16 +49,20 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Setup Minikube cluster
-        # Should be set back with correct version once https://github.com/radtriste/setup-minikube/tree/issue_49 is done
-        uses: medyagh/setup-minikube@v0.0.10
+      - name: Cache Minikube Download
+        id: cache-minikube-download
+        uses: actions/cache@v3
         with:
-          addons: registry,metrics-server
-          kubernetes-version: ${{ env.KUBERNETES_VERSION }}
-          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-          cpus: max
-          memory: max
-          insecure-registry: localhost:5000,192.168.0.0/16
+          key: ${{ runner.os }}-minikube-${{ env.MINIKUBE_VERSION }}
+          path: |
+            ~/.minikube/download/
+
+      - name: Setup Minikube cluster
+        run: |
+          # Install minikube at $HOME/.local/bin
+          ./hack/ci/install-minikube.sh $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          minikube start --kubernetes-version ${{ env.KUBERNETES_VERSION }} --addons=registry --insecure-registry=localhost:5000,192.168.0.0/16 --cpus=max --memory=max
       
       - name: Wait for Minikube up and running
         run: |

--- a/hack/ci/install-minikube.sh
+++ b/hack/ci/install-minikube.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2023 Red Hat, Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+install_path=$1
+default_minikube_version=v1.31.1
+
+if [[ -z ${MINIKUBE_VERSION} ]]; then
+  MINIKUBE_VERSION=$default_minikube_version
+fi
+
+download_path="${HOME}/.minikube/download/"
+
+echo "---> Minikube version to install is ${MINIKUBE_VERSION}"
+
+# get the arch and os
+arch=$(uname -m)
+case $(uname -m) in
+"x86_64") arch="amd64" ;;
+"aarch64") arch="arm64" ;;
+esac
+os=$(uname | awk '{print tolower($0)}')
+
+if [ -e "${download_path}/minikube-${os}-${arch}" ]; then
+  echo "---> Minikube ${MINIKUBE_VERSION} (OS ${os} Architecture ${arch}) already exists in '${download_path}', skipping downloading"
+else
+  mkdir -p "${download_path}"
+  cd "${download_path}"
+  echo "---> Downloading minikube ${MINIKUBE_VERSION} (OS ${os} Architecture ${arch}) to ${download_path}"
+  curl -LO "https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-${os}-${arch}"
+  cd -
+fi
+
+if [ -z "${install_path}" ]; then
+  install_path="${HOME}/Downloads"
+  [[ "${os}" == "darwin" ]]; install_path="${HOME}/Downloads"
+fi
+
+echo "---> Ensuring minikube installation at ${install_path}"
+
+mkdir -p "${install_path}"
+chmod +x "${install_path}"
+cp "${download_path}/minikube-${os}-${arch}" "${install_path}/minikube"

--- a/hack/ci/install-minikube.sh
+++ b/hack/ci/install-minikube.sh
@@ -45,8 +45,8 @@ else
 fi
 
 if [ -z "${install_path}" ]; then
-  install_path="${HOME}/Downloads"
-  [[ "${os}" == "darwin" ]]; install_path="${HOME}/Downloads"
+  install_path="${HOME}/runner/bin"
+  [[ "${os}" == "darwin" ]]; install_path="${HOME}/runner/bin"
 fi
 
 echo "---> Ensuring minikube installation at ${install_path}"


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
After Apache migration, we need to ensure that our actions follow the organization's policy.
I've removed the third-party actions and added a new script to download, cache, and set up minikube for e2e.

**Motivation for the change:**
Fix #259 

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>