### PR TITLE
KOGITO-9819: [Operator image builder] Persistence not working in the image produced by operator generated image

### DIFF
--- a/container-builder/builder/kubernetes/builder_kaniko_test.go
+++ b/container-builder/builder/kubernetes/builder_kaniko_test.go
@@ -137,6 +137,9 @@ func TestNewBuildWithKanikoWithBuildArgsAndEnv(t *testing.T) {
 		WithBuildArgs([]v1.EnvVar{{
 			Name:  "QUARKUS_EXTENSIONS",
 			Value: "extension1,extension2",
+		}, {
+			Name:  "MY_PROPERTY",
+			Value: "my_property_value",
 		}}).
 		WithEnvs([]v1.EnvVar{{
 			Name:  "MYENV",
@@ -159,5 +162,6 @@ func TestNewBuildWithKanikoWithBuildArgsAndEnv(t *testing.T) {
 	assert.NotNil(t, pod)
 
 	assert.Subset(t, pod.Spec.Containers[0].Args, []string{"--build-arg=QUARKUS_EXTENSIONS=extension1,extension2"})
+	assert.Subset(t, pod.Spec.Containers[0].Args, []string{"--build-arg=MY_PROPERTY=my_property_value"})
 	assert.Subset(t, pod.Spec.Containers[0].Env, []v1.EnvVar{{Name: "MYENV", Value: "value"}})
 }

--- a/container-builder/builder/kubernetes/kaniko.go
+++ b/container-builder/builder/kubernetes/kaniko.go
@@ -124,7 +124,9 @@ func addKanikoTaskToPod(ctx context.Context, c client.Client, build *api.Contain
 		return err
 	}
 	if len(buildArgs) > 0 {
-		args = append(args, fmt.Sprintf("%s=%s", kanikoBuildArgs, strings.Join(buildArgs, ",")))
+		for _, buildArg := range buildArgs {
+			args = append(args, fmt.Sprintf("%s=%s", kanikoBuildArgs, buildArg))
+		}
 	}
 
 	container := corev1.Container{


### PR DESCRIPTION
    - Fixes the parameters construction for the kaniko builder which produced the issue.

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
When testing the tuning of the sonataflow-operator-builder-config Docker file, it was detected that introduced ARGs where not processed well at the time of producing the kaniko --build-param's for the kaniko image build.
This change fixes these parameters processing.

**Motivation for the change:**
https://issues.redhat.com/browse/KOGITO-9819

**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>