### PR TITLE
KOGITO-9739: Create OpenShift routes with HTTPS for SonataFlows

### DIFF
--- a/utils/openshift/route_test.go
+++ b/utils/openshift/route_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,30 +15,33 @@
 package openshift
 
 import (
-	v1 "github.com/openshift/api/route/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
 
-	"github.com/kiegroup/kogito-serverless-operator/workflowproj"
+	v1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorapi "github.com/kiegroup/kogito-serverless-operator/api/v1alpha08"
 )
 
-func RouteForWorkflow(workflow *operatorapi.SonataFlow) (*v1.Route, error) {
-	route := &v1.Route{
+const (
+	WorkflowName      = "helloworld"
+	WorkflowNamespace = "usecase1"
+)
+
+func TestRouteForWorkflow(t *testing.T) {
+	workflow := &operatorapi.SonataFlow{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      workflow.Name,
-			Namespace: workflow.Namespace,
-		},
-		Spec: v1.RouteSpec{
-			To: v1.RouteTargetReference{
-				Kind: "Service",
-				Name: workflow.Name,
-			},
-			TLS: &v1.TLSConfig{
-				Termination: v1.TLSTerminationEdge,
-			},
+			Name:      WorkflowName,
+			Namespace: WorkflowNamespace,
 		},
 	}
-	workflowproj.SetDefaultLabels(workflow, route)
-	return route, nil
+	route, err := RouteForWorkflow(workflow)
+	assert.NotNil(t, route)
+	assert.Nil(t, err)
+	assert.Equal(t, WorkflowName, route.ObjectMeta.Name)
+	assert.Equal(t, WorkflowNamespace, route.ObjectMeta.Namespace)
+	assert.Equal(t, "Service", route.Spec.To.Kind)
+	assert.Equal(t, WorkflowName, route.Spec.To.Name)
+	assert.Equal(t, v1.TLSTerminationEdge, route.Spec.TLS.Termination)
 }


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>