### PR TITLE
[KOGITO-9857] Fix podTemplate struct to json inline

### DIFF
--- a/api/v1alpha08/sonataflow_types.go
+++ b/api/v1alpha08/sonataflow_types.go
@@ -548,7 +548,8 @@ type FlowPodTemplateSpec struct {
 	// One can change this attribute in order to override the defaults provided by the operator.
 	// +optional
 	Container FlowContainer `json:"container,omitempty"`
-	PodSpec   FlowPodSpec   `json:",omitempty"`
+	// +optional
+	FlowPodSpec `json:",inline"`
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 }
@@ -649,6 +650,7 @@ type SonataFlowSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="resources"
 	Resources WorkflowResources `json:"resources,omitempty"`
 	// PodTemplate describes the deployment details of this SonataFlow instance.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="podTemplate"
 	PodTemplate FlowPodTemplateSpec `json:"podTemplate,omitempty"`
 }
 

--- a/api/v1alpha08/zz_generated.deepcopy.go
+++ b/api/v1alpha08/zz_generated.deepcopy.go
@@ -485,7 +485,7 @@ func (in *FlowPodSpec) DeepCopy() *FlowPodSpec {
 func (in *FlowPodTemplateSpec) DeepCopyInto(out *FlowPodTemplateSpec) {
 	*out = *in
 	in.Container.DeepCopyInto(&out.Container)
-	in.PodSpec.DeepCopyInto(&out.PodSpec)
+	in.FlowPodSpec.DeepCopyInto(&out.FlowPodSpec)
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)

--- a/bundle.osl/manifests/logic-operator-rhel8.clusterserviceversion.yaml
+++ b/bundle.osl/manifests/logic-operator-rhel8.clusterserviceversion.yaml
@@ -106,8 +106,10 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Application Runtime
-    description: OpenShift Serverless Logic Kubernetes Operator for deploying workflow applications based on the CNCF Serverless Workflow specification
-    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    description: OpenShift Serverless Logic Kubernetes Operator for deploying workflow
+      applications based on the CNCF Serverless Workflow specification
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.25.0
     operators.operatorframework.io/internal-objects: '["sonataflowbuilds.sonataflow.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -119,125 +121,152 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: SonataFlowBuild is an internal custom resource to control workflow build instances in the target platform
-        displayName: Sonata Flow Build
-        kind: SonataFlowBuild
-        name: sonataflowbuilds.sonataflow.org
-        resources:
-          - kind: BuildConfig
-            name: An Openshift Build Config
-            version: build.openshift.io/v1
-        specDescriptors:
-          - description: 'Arguments lists the command line arguments to send to the internal builder command. Depending on the build method you might set this attribute instead of BuildArgs. For example: ".spec.arguments=verbose=3". Please see the SonataFlow guides.'
-            displayName: Arguments
-            path: arguments
-          - description: Optional build arguments that can be set to the internal build (e.g. Docker ARG)
-            displayName: BuildArgs
-            path: buildArgs
-          - description: Optional environment variables to add to the internal build
-            displayName: Envs
-            path: envs
-          - description: Resources optional compute resource requirements for the builder
-            displayName: Resources
-            path: resources
-          - description: Timeout defines the Build maximum execution duration. The Build deadline is set to the Build start time plus the Timeout duration. If the Build deadline is exceeded, the Build context is canceled, and its phase set to BuildPhaseFailed.
-            displayName: Timeout
-            path: timeout
-        statusDescriptors:
-          - description: BuildPhase Current phase of the build
-            displayName: BuildPhase
-            path: buildPhase
-          - description: Error Last error found during build
-            displayName: Error
-            path: error
-          - description: ImageTag The final image tag produced by this build instance
-            displayName: ImageTag
-            path: imageTag
-          - description: InnerBuild is a reference to an internal build object, which can be anything known only to internal builders.
-            displayName: InnerBuild
-            path: innerBuild
-        version: v1alpha08
-      - description: SonataFlowPlatform is the descriptor for the workflow platform infrastructure.
-        displayName: Sonata Flow Platform
-        kind: SonataFlowPlatform
-        name: sonataflowplatforms.sonataflow.org
-        resources:
-          - kind: Namespace
-            name: The Namespace controlled by the platform
-            version: v1
-        specDescriptors:
-          - description: Build Attributes for building workflows in the target platform
-            displayName: Build
-            path: build
-          - description: 'Arguments lists the command line arguments to send to the internal builder command. Depending on the build method you might set this attribute instead of BuildArgs. For example: ".spec.arguments=verbose=3". Please see the SonataFlow guides.'
-            displayName: Arguments
-            path: build.template.arguments
-          - description: Optional build arguments that can be set to the internal build (e.g. Docker ARG)
-            displayName: BuildArgs
-            path: build.template.buildArgs
-          - description: Optional environment variables to add to the internal build
-            displayName: Envs
-            path: build.template.envs
-          - description: Resources optional compute resource requirements for the builder
-            displayName: Resources
-            path: build.template.resources
-          - description: Timeout defines the Build maximum execution duration. The Build deadline is set to the Build start time plus the Timeout duration. If the Build deadline is exceeded, the Build context is canceled, and its phase set to BuildPhaseFailed.
-            displayName: Timeout
-            path: build.template.timeout
-          - description: DevMode Attributes for running workflows in devmode (immutable, no build required)
-            displayName: DevMode
-            path: devMode
-        statusDescriptors:
-          - description: Cluster what kind of cluster you're running (ie, plain Kubernetes or OpenShift)
-            displayName: cluster
-            path: cluster
-          - description: Info generic information related to the build
-            displayName: info
-            path: info
-          - description: Version the operator version controlling this Platform
-            displayName: version
-            path: version
-        version: v1alpha08
-      - description: SonataFlow is the descriptor representation for a workflow application based on the CNCF Serverless Workflow specification.
-        displayName: Sonata Flow
-        kind: SonataFlow
-        name: sonataflows.sonataflow.org
-        resources:
-          - kind: Deployment
-            name: A Deployment for the Flow
-            version: apps/v1
-          - kind: Service
-            name: A Service for the Flow
-            version: v1
-          - kind: SonataFlowBuild
-            name: A SonataFlow Build
-            version: sonataflow.org/v1alpha08
-          - kind: Route
-            name: An OpenShift Route for the Flow
-            version: route.openshift.io/v1
-          - kind: ConfigMap
-            name: The ConfigMaps with Flow definition and additional configuration files
-            version: v1
-        specDescriptors:
-          - description: Flow the workflow definition.
-            displayName: flow
-            path: flow
-          - description: Resources workflow resources that are linked to this workflow definition. For example, a collection of OpenAPI specification files.
-            displayName: resources
-            path: resources
-        statusDescriptors:
-          - description: Address is used as a part of Addressable interface (status.address.url) for knative
-            displayName: address
-            path: address
-          - description: Endpoint is an externally accessible URL of the workflow
-            displayName: endpoint
-            path: endpoint
-          - displayName: lastTimeRecoverAttempt
-            path: lastTimeRecoverAttempt
-          - description: keeps track of how many failure recovers a given workflow had so far
-            displayName: recoverFailureAttempts
-            path: recoverFailureAttempts
-        version: v1alpha08
+    - description: SonataFlowBuild is an internal custom resource to control workflow
+        build instances in the target platform
+      displayName: Sonata Flow Build
+      kind: SonataFlowBuild
+      name: sonataflowbuilds.sonataflow.org
+      resources:
+      - kind: BuildConfig
+        name: An Openshift Build Config
+        version: build.openshift.io/v1
+      specDescriptors:
+      - description: 'Arguments lists the command line arguments to send to the internal
+          builder command. Depending on the build method you might set this attribute
+          instead of BuildArgs. For example: ".spec.arguments=verbose=3". Please see
+          the SonataFlow guides.'
+        displayName: Arguments
+        path: arguments
+      - description: Optional build arguments that can be set to the internal build
+          (e.g. Docker ARG)
+        displayName: BuildArgs
+        path: buildArgs
+      - description: Optional environment variables to add to the internal build
+        displayName: Envs
+        path: envs
+      - description: Resources optional compute resource requirements for the builder
+        displayName: Resources
+        path: resources
+      - description: Timeout defines the Build maximum execution duration. The Build
+          deadline is set to the Build start time plus the Timeout duration. If the
+          Build deadline is exceeded, the Build context is canceled, and its phase
+          set to BuildPhaseFailed.
+        displayName: Timeout
+        path: timeout
+      statusDescriptors:
+      - description: BuildPhase Current phase of the build
+        displayName: BuildPhase
+        path: buildPhase
+      - description: Error Last error found during build
+        displayName: Error
+        path: error
+      - description: ImageTag The final image tag produced by this build instance
+        displayName: ImageTag
+        path: imageTag
+      - description: InnerBuild is a reference to an internal build object, which
+          can be anything known only to internal builders.
+        displayName: InnerBuild
+        path: innerBuild
+      version: v1alpha08
+    - description: SonataFlowPlatform is the descriptor for the workflow platform
+        infrastructure.
+      displayName: Sonata Flow Platform
+      kind: SonataFlowPlatform
+      name: sonataflowplatforms.sonataflow.org
+      resources:
+      - kind: Namespace
+        name: The Namespace controlled by the platform
+        version: v1
+      specDescriptors:
+      - description: Build Attributes for building workflows in the target platform
+        displayName: Build
+        path: build
+      - description: 'Arguments lists the command line arguments to send to the internal
+          builder command. Depending on the build method you might set this attribute
+          instead of BuildArgs. For example: ".spec.arguments=verbose=3". Please see
+          the SonataFlow guides.'
+        displayName: Arguments
+        path: build.template.arguments
+      - description: Optional build arguments that can be set to the internal build
+          (e.g. Docker ARG)
+        displayName: BuildArgs
+        path: build.template.buildArgs
+      - description: Optional environment variables to add to the internal build
+        displayName: Envs
+        path: build.template.envs
+      - description: Resources optional compute resource requirements for the builder
+        displayName: Resources
+        path: build.template.resources
+      - description: Timeout defines the Build maximum execution duration. The Build
+          deadline is set to the Build start time plus the Timeout duration. If the
+          Build deadline is exceeded, the Build context is canceled, and its phase
+          set to BuildPhaseFailed.
+        displayName: Timeout
+        path: build.template.timeout
+      - description: DevMode Attributes for running workflows in devmode (immutable,
+          no build required)
+        displayName: DevMode
+        path: devMode
+      statusDescriptors:
+      - description: Cluster what kind of cluster you're running (ie, plain Kubernetes
+          or OpenShift)
+        displayName: cluster
+        path: cluster
+      - description: Info generic information related to the build
+        displayName: info
+        path: info
+      - description: Version the operator version controlling this Platform
+        displayName: version
+        path: version
+      version: v1alpha08
+    - description: SonataFlow is the descriptor representation for a workflow application
+        based on the CNCF Serverless Workflow specification.
+      displayName: Sonata Flow
+      kind: SonataFlow
+      name: sonataflows.sonataflow.org
+      resources:
+      - kind: Deployment
+        name: A Deployment for the Flow
+        version: apps/v1
+      - kind: Service
+        name: A Service for the Flow
+        version: v1
+      - kind: SonataFlowBuild
+        name: A SonataFlow Build
+        version: sonataflow.org/v1alpha08
+      - kind: Route
+        name: An OpenShift Route for the Flow
+        version: route.openshift.io/v1
+      - kind: ConfigMap
+        name: The ConfigMaps with Flow definition and additional configuration files
+        version: v1
+      specDescriptors:
+      - description: Flow the workflow definition.
+        displayName: flow
+        path: flow
+      - description: PodTemplate describes the deployment details of this SonataFlow
+          instance.
+        displayName: podTemplate
+        path: podTemplate
+      - description: Resources workflow resources that are linked to this workflow
+          definition. For example, a collection of OpenAPI specification files.
+        displayName: resources
+        path: resources
+      statusDescriptors:
+      - description: Address is used as a part of Addressable interface (status.address.url)
+          for knative
+        displayName: address
+        path: address
+      - description: Endpoint is an externally accessible URL of the workflow
+        displayName: endpoint
+        path: endpoint
+      - displayName: lastTimeRecoverAttempt
+        path: lastTimeRecoverAttempt
+      - description: keeps track of how many failure recovers a given workflow had
+          so far
+        displayName: recoverFailureAttempts
+        path: recoverFailureAttempts
+      version: v1alpha08
   description: |-
     OpenShift Serverless Logic Kubernetes Operator for deploying workflow applications
     based on the [CNCF Serverless Workflow specification](https://serverlessworkflow.io/):
@@ -248,407 +277,402 @@ spec:
   install:
     spec:
       clusterPermissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-                - pods
-                - pods/exec
-                - services
-                - services/finalizers
-                - namespaces
-                - serviceaccounts
-                - persistentvolumeclaims
-                - secrets
-                - events
-                - deployments
-                - nodes
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - apps
-              resources:
-                - configmaps
-                - pods
-                - pods/exec
-                - services
-                - services/finalizers
-                - namespaces
-                - serviceaccounts
-                - persistentvolumeclaims
-                - secrets
-                - events
-                - deployments
-                - nodes
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - roles
-                - rolebindings
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - coordination.k8s.io
-              resources:
-                - leases
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - sonataflow.org
-              resources:
-                - sonataflowbuilds
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - sonataflow.org
-              resources:
-                - sonataflowbuilds/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - sonataflow.org
-              resources:
-                - sonataflowbuilds/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - sonataflow.org
-              resources:
-                - sonataflowplatforms
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - sonataflow.org
-              resources:
-                - sonataflowplatforms/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - sonataflow.org
-              resources:
-                - sonataflowplatforms/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - sonataflow.org
-              resources:
-                - sonataflows
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - sonataflow.org
-              resources:
-                - sonataflows/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - sonataflow.org
-              resources:
-                - sonataflows/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - route.openshift.io
-              resources:
-                - route
-                - routes
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - route.openshift.io
-              resources:
-                - route/finalizers
-                - routes/finalizers
-              verbs:
-                - get
-                - list
-                - create
-                - update
-                - delete
-                - deletecollection
-                - patch
-                - watch
-            - apiGroups:
-                - image.openshift.io
-              resources:
-                - imagestreams
-                - imagestreamtags
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - image.openshift.io
-              resources:
-                - imagestreams/finalizers
-                - imagestreamtags/finalizers
-              verbs:
-                - get
-                - list
-                - create
-                - update
-                - delete
-                - deletecollection
-                - patch
-                - watch
-            - apiGroups:
-                - build.openshift.io
-              resources:
-                - buildconfigs
-                - builds
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - build.openshift.io
-              resources:
-                - buildconfigs/finalizers
-                - builds/finalizers
-              verbs:
-                - get
-                - list
-                - create
-                - update
-                - delete
-                - deletecollection
-                - patch
-                - watch
-            - apiGroups:
-                - build.openshift.io
-              resources:
-                - buildconfigs/instantiatebinary
-              verbs:
-                - create
-            - apiGroups:
-                - authentication.k8s.io
-              resources:
-                - tokenreviews
-              verbs:
-                - create
-            - apiGroups:
-                - authorization.k8s.io
-              resources:
-                - subjectaccessreviews
-              verbs:
-                - create
-          serviceAccountName: logic-operator-rhel8-controller-manager
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - pods
+          - pods/exec
+          - services
+          - services/finalizers
+          - namespaces
+          - serviceaccounts
+          - persistentvolumeclaims
+          - secrets
+          - events
+          - deployments
+          - nodes
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - configmaps
+          - pods
+          - pods/exec
+          - services
+          - services/finalizers
+          - namespaces
+          - serviceaccounts
+          - persistentvolumeclaims
+          - secrets
+          - events
+          - deployments
+          - nodes
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - sonataflow.org
+          resources:
+          - sonataflowbuilds
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - sonataflow.org
+          resources:
+          - sonataflowbuilds/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - sonataflow.org
+          resources:
+          - sonataflowbuilds/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - sonataflow.org
+          resources:
+          - sonataflowplatforms
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - sonataflow.org
+          resources:
+          - sonataflowplatforms/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - sonataflow.org
+          resources:
+          - sonataflowplatforms/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - sonataflow.org
+          resources:
+          - sonataflows
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - sonataflow.org
+          resources:
+          - sonataflows/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - sonataflow.org
+          resources:
+          - sonataflows/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - route
+          - routes
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - route/finalizers
+          - routes/finalizers
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - patch
+          - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          - imagestreamtags
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams/finalizers
+          - imagestreamtags/finalizers
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - patch
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - builds
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - buildconfigs/finalizers
+          - builds/finalizers
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - patch
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - buildconfigs/instantiatebinary
+          verbs:
+          - create
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: logic-operator-rhel8-controller-manager
       deployments:
-        - label:
-            control-plane: controller-manager
-          name: logic-operator-rhel8-controller-manager
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
+      - label:
+          control-plane: controller-manager
+        name: logic-operator-rhel8-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
                 control-plane: controller-manager
-            strategy: {}
-            template:
-              metadata:
-                annotations:
-                  kubectl.kubernetes.io/default-container: manager
-                labels:
-                  control-plane: controller-manager
-              spec:
-                containers:
-                  - args:
-                      - --secure-listen-address=0.0.0.0:8443
-                      - --upstream=http://127.0.0.1:8080/
-                      - --logtostderr=true
-                      - --v=0
-                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
-                    name: kube-rbac-proxy
-                    ports:
-                      - containerPort: 8443
-                        name: https
-                        protocol: TCP
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 128Mi
-                      requests:
-                        cpu: 5m
-                        memory: 64Mi
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop:
-                          - ALL
-                  - args:
-                      - --health-probe-bind-address=:8081
-                      - --metrics-bind-address=127.0.0.1:8080
-                      - --leader-elect
-                    command:
-                      - /usr/local/bin/manager
-                    env:
-                      - name: POD_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.namespace
-                    image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-operator-rhel8@sha256:24c2e62bff1f2f7e5579b990e44206ac019bd00f5ca546b069471fc1af34ed75
-                    livenessProbe:
-                      httpGet:
-                        path: /healthz
-                        port: 8081
-                      initialDelaySeconds: 15
-                      periodSeconds: 20
-                    name: manager
-                    readinessProbe:
-                      httpGet:
-                        path: /readyz
-                        port: 8081
-                      initialDelaySeconds: 5
-                      periodSeconds: 10
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 128Mi
-                      requests:
-                        cpu: 10m
-                        memory: 64Mi
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop:
-                          - ALL
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
                 securityContext:
-                  runAsNonRoot: true
-                serviceAccountName: logic-operator-rhel8-controller-manager
-                terminationGracePeriodSeconds: 10
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /usr/local/bin/manager
+                env:
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-operator-rhel8:1.30.0
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: logic-operator-rhel8-controller-manager
+              terminationGracePeriodSeconds: 10
       permissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - coordination.k8s.io
-              resources:
-                - leases
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - ""
-              resources:
-                - events
-              verbs:
-                - create
-                - patch
-          serviceAccountName: logic-operator-rhel8-controller-manager
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: logic-operator-rhel8-controller-manager
     strategy: deployment
   installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
   keywords:
-    - sonataflow
-    - cncf
-    - serverless
-    - serverlessworkflow
+  - sonataflow
+  - cncf
+  - serverless
+  - serverlessworkflow
   links:
-    - name: Product Page
-      url: https://sonataflow.org/serverlessworkflow/latest/index.html
+  - name: Product Page
+    url: https://sonataflow.org/serverlessworkflow/latest/index.html
   maintainers:
-    - email: bsig-cloud@redhat.com
-      name: Red Hat
+  - email: bsig-cloud@redhat.com
+    name: Red Hat
   maturity: alpha
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
-  relatedImages:
-    - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
-      name: kube-rbac-proxy
-    - image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-operator-rhel8@sha256:24c2e62bff1f2f7e5579b990e44206ac019bd00f5ca546b069471fc1af34ed75
-      name: manager
   version: 1.30.0

--- a/bundle.osl/manifests/logic-operator-rhel8.clusterserviceversion.yaml
+++ b/bundle.osl/manifests/logic-operator-rhel8.clusterserviceversion.yaml
@@ -106,10 +106,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Application Runtime
-    description: OpenShift Serverless Logic Kubernetes Operator for deploying workflow
-      applications based on the CNCF Serverless Workflow specification
-    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
-      Platform Plus"]'
+    description: OpenShift Serverless Logic Kubernetes Operator for deploying workflow applications based on the CNCF Serverless Workflow specification
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.25.0
     operators.operatorframework.io/internal-objects: '["sonataflowbuilds.sonataflow.org"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -121,152 +119,128 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: SonataFlowBuild is an internal custom resource to control workflow
-        build instances in the target platform
-      displayName: Sonata Flow Build
-      kind: SonataFlowBuild
-      name: sonataflowbuilds.sonataflow.org
-      resources:
-      - kind: BuildConfig
-        name: An Openshift Build Config
-        version: build.openshift.io/v1
-      specDescriptors:
-      - description: 'Arguments lists the command line arguments to send to the internal
-          builder command. Depending on the build method you might set this attribute
-          instead of BuildArgs. For example: ".spec.arguments=verbose=3". Please see
-          the SonataFlow guides.'
-        displayName: Arguments
-        path: arguments
-      - description: Optional build arguments that can be set to the internal build
-          (e.g. Docker ARG)
-        displayName: BuildArgs
-        path: buildArgs
-      - description: Optional environment variables to add to the internal build
-        displayName: Envs
-        path: envs
-      - description: Resources optional compute resource requirements for the builder
-        displayName: Resources
-        path: resources
-      - description: Timeout defines the Build maximum execution duration. The Build
-          deadline is set to the Build start time plus the Timeout duration. If the
-          Build deadline is exceeded, the Build context is canceled, and its phase
-          set to BuildPhaseFailed.
-        displayName: Timeout
-        path: timeout
-      statusDescriptors:
-      - description: BuildPhase Current phase of the build
-        displayName: BuildPhase
-        path: buildPhase
-      - description: Error Last error found during build
-        displayName: Error
-        path: error
-      - description: ImageTag The final image tag produced by this build instance
-        displayName: ImageTag
-        path: imageTag
-      - description: InnerBuild is a reference to an internal build object, which
-          can be anything known only to internal builders.
-        displayName: InnerBuild
-        path: innerBuild
-      version: v1alpha08
-    - description: SonataFlowPlatform is the descriptor for the workflow platform
-        infrastructure.
-      displayName: Sonata Flow Platform
-      kind: SonataFlowPlatform
-      name: sonataflowplatforms.sonataflow.org
-      resources:
-      - kind: Namespace
-        name: The Namespace controlled by the platform
-        version: v1
-      specDescriptors:
-      - description: Build Attributes for building workflows in the target platform
-        displayName: Build
-        path: build
-      - description: 'Arguments lists the command line arguments to send to the internal
-          builder command. Depending on the build method you might set this attribute
-          instead of BuildArgs. For example: ".spec.arguments=verbose=3". Please see
-          the SonataFlow guides.'
-        displayName: Arguments
-        path: build.template.arguments
-      - description: Optional build arguments that can be set to the internal build
-          (e.g. Docker ARG)
-        displayName: BuildArgs
-        path: build.template.buildArgs
-      - description: Optional environment variables to add to the internal build
-        displayName: Envs
-        path: build.template.envs
-      - description: Resources optional compute resource requirements for the builder
-        displayName: Resources
-        path: build.template.resources
-      - description: Timeout defines the Build maximum execution duration. The Build
-          deadline is set to the Build start time plus the Timeout duration. If the
-          Build deadline is exceeded, the Build context is canceled, and its phase
-          set to BuildPhaseFailed.
-        displayName: Timeout
-        path: build.template.timeout
-      - description: DevMode Attributes for running workflows in devmode (immutable,
-          no build required)
-        displayName: DevMode
-        path: devMode
-      statusDescriptors:
-      - description: Cluster what kind of cluster you're running (ie, plain Kubernetes
-          or OpenShift)
-        displayName: cluster
-        path: cluster
-      - description: Info generic information related to the build
-        displayName: info
-        path: info
-      - description: Version the operator version controlling this Platform
-        displayName: version
-        path: version
-      version: v1alpha08
-    - description: SonataFlow is the descriptor representation for a workflow application
-        based on the CNCF Serverless Workflow specification.
-      displayName: Sonata Flow
-      kind: SonataFlow
-      name: sonataflows.sonataflow.org
-      resources:
-      - kind: Deployment
-        name: A Deployment for the Flow
-        version: apps/v1
-      - kind: Service
-        name: A Service for the Flow
-        version: v1
-      - kind: SonataFlowBuild
-        name: A SonataFlow Build
-        version: sonataflow.org/v1alpha08
-      - kind: Route
-        name: An OpenShift Route for the Flow
-        version: route.openshift.io/v1
-      - kind: ConfigMap
-        name: The ConfigMaps with Flow definition and additional configuration files
-        version: v1
-      specDescriptors:
-      - description: Flow the workflow definition.
-        displayName: flow
-        path: flow
-      - description: PodTemplate describes the deployment details of this SonataFlow
-          instance.
-        displayName: podTemplate
-        path: podTemplate
-      - description: Resources workflow resources that are linked to this workflow
-          definition. For example, a collection of OpenAPI specification files.
-        displayName: resources
-        path: resources
-      statusDescriptors:
-      - description: Address is used as a part of Addressable interface (status.address.url)
-          for knative
-        displayName: address
-        path: address
-      - description: Endpoint is an externally accessible URL of the workflow
-        displayName: endpoint
-        path: endpoint
-      - displayName: lastTimeRecoverAttempt
-        path: lastTimeRecoverAttempt
-      - description: keeps track of how many failure recovers a given workflow had
-          so far
-        displayName: recoverFailureAttempts
-        path: recoverFailureAttempts
-      version: v1alpha08
+      - description: SonataFlowBuild is an internal custom resource to control workflow build instances in the target platform
+        displayName: Sonata Flow Build
+        kind: SonataFlowBuild
+        name: sonataflowbuilds.sonataflow.org
+        resources:
+          - kind: BuildConfig
+            name: An Openshift Build Config
+            version: build.openshift.io/v1
+        specDescriptors:
+          - description: 'Arguments lists the command line arguments to send to the internal builder command. Depending on the build method you might set this attribute instead of BuildArgs. For example: ".spec.arguments=verbose=3". Please see the SonataFlow guides.'
+            displayName: Arguments
+            path: arguments
+          - description: Optional build arguments that can be set to the internal build (e.g. Docker ARG)
+            displayName: BuildArgs
+            path: buildArgs
+          - description: Optional environment variables to add to the internal build
+            displayName: Envs
+            path: envs
+          - description: Resources optional compute resource requirements for the builder
+            displayName: Resources
+            path: resources
+          - description: Timeout defines the Build maximum execution duration. The Build deadline is set to the Build start time plus the Timeout duration. If the Build deadline is exceeded, the Build context is canceled, and its phase set to BuildPhaseFailed.
+            displayName: Timeout
+            path: timeout
+        statusDescriptors:
+          - description: BuildPhase Current phase of the build
+            displayName: BuildPhase
+            path: buildPhase
+          - description: Error Last error found during build
+            displayName: Error
+            path: error
+          - description: ImageTag The final image tag produced by this build instance
+            displayName: ImageTag
+            path: imageTag
+          - description: InnerBuild is a reference to an internal build object, which can be anything known only to internal builders.
+            displayName: InnerBuild
+            path: innerBuild
+        version: v1alpha08
+      - description: SonataFlowPlatform is the descriptor for the workflow platform infrastructure.
+        displayName: Sonata Flow Platform
+        kind: SonataFlowPlatform
+        name: sonataflowplatforms.sonataflow.org
+        resources:
+          - kind: Namespace
+            name: The Namespace controlled by the platform
+            version: v1
+        specDescriptors:
+          - description: Build Attributes for building workflows in the target platform
+            displayName: Build
+            path: build
+          - description: 'Arguments lists the command line arguments to send to the internal builder command. Depending on the build method you might set this attribute instead of BuildArgs. For example: ".spec.arguments=verbose=3". Please see the SonataFlow guides.'
+            displayName: Arguments
+            path: build.template.arguments
+          - description: Optional build arguments that can be set to the internal build (e.g. Docker ARG)
+            displayName: BuildArgs
+            path: build.template.buildArgs
+          - description: Optional environment variables to add to the internal build
+            displayName: Envs
+            path: build.template.envs
+          - description: Resources optional compute resource requirements for the builder
+            displayName: Resources
+            path: build.template.resources
+          - description: Timeout defines the Build maximum execution duration. The Build deadline is set to the Build start time plus the Timeout duration. If the Build deadline is exceeded, the Build context is canceled, and its phase set to BuildPhaseFailed.
+            displayName: Timeout
+            path: build.template.timeout
+          - description: DevMode Attributes for running workflows in devmode (immutable, no build required)
+            displayName: DevMode
+            path: devMode
+        statusDescriptors:
+          - description: Cluster what kind of cluster you're running (ie, plain Kubernetes or OpenShift)
+            displayName: cluster
+            path: cluster
+          - description: Info generic information related to the build
+            displayName: info
+            path: info
+          - description: Version the operator version controlling this Platform
+            displayName: version
+            path: version
+        version: v1alpha08
+      - description: SonataFlow is the descriptor representation for a workflow application based on the CNCF Serverless Workflow specification.
+        displayName: Sonata Flow
+        kind: SonataFlow
+        name: sonataflows.sonataflow.org
+        resources:
+          - kind: Deployment
+            name: A Deployment for the Flow
+            version: apps/v1
+          - kind: Service
+            name: A Service for the Flow
+            version: v1
+          - kind: SonataFlowBuild
+            name: A SonataFlow Build
+            version: sonataflow.org/v1alpha08
+          - kind: Route
+            name: An OpenShift Route for the Flow
+            version: route.openshift.io/v1
+          - kind: ConfigMap
+            name: The ConfigMaps with Flow definition and additional configuration files
+            version: v1
+        specDescriptors:
+          - description: Flow the workflow definition.
+            displayName: flow
+            path: flow
+          - description: PodTemplate describes the deployment details of this SonataFlow instance.
+            displayName: podTemplate
+            path: podTemplate
+          - description: Resources workflow resources that are linked to this workflow definition. For example, a collection of OpenAPI specification files.
+            displayName: resources
+            path: resources
+        statusDescriptors:
+          - description: Address is used as a part of Addressable interface (status.address.url) for knative
+            displayName: address
+            path: address
+          - description: Endpoint is an externally accessible URL of the workflow
+            displayName: endpoint
+            path: endpoint
+          - displayName: lastTimeRecoverAttempt
+            path: lastTimeRecoverAttempt
+          - description: keeps track of how many failure recovers a given workflow had so far
+            displayName: recoverFailureAttempts
+            path: recoverFailureAttempts
+        version: v1alpha08
   description: |-
     OpenShift Serverless Logic Kubernetes Operator for deploying workflow applications
     based on the [CNCF Serverless Workflow specification](https://serverlessworkflow.io/):
@@ -277,402 +251,407 @@ spec:
   install:
     spec:
       clusterPermissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - pods
-          - pods/exec
-          - services
-          - services/finalizers
-          - namespaces
-          - serviceaccounts
-          - persistentvolumeclaims
-          - secrets
-          - events
-          - deployments
-          - nodes
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - configmaps
-          - pods
-          - pods/exec
-          - services
-          - services/finalizers
-          - namespaces
-          - serviceaccounts
-          - persistentvolumeclaims
-          - secrets
-          - events
-          - deployments
-          - nodes
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - roles
-          - rolebindings
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - sonataflow.org
-          resources:
-          - sonataflowbuilds
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - sonataflow.org
-          resources:
-          - sonataflowbuilds/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - sonataflow.org
-          resources:
-          - sonataflowbuilds/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - sonataflow.org
-          resources:
-          - sonataflowplatforms
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - sonataflow.org
-          resources:
-          - sonataflowplatforms/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - sonataflow.org
-          resources:
-          - sonataflowplatforms/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - sonataflow.org
-          resources:
-          - sonataflows
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - sonataflow.org
-          resources:
-          - sonataflows/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - sonataflow.org
-          resources:
-          - sonataflows/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - route.openshift.io
-          resources:
-          - route
-          - routes
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - route.openshift.io
-          resources:
-          - route/finalizers
-          - routes/finalizers
-          verbs:
-          - get
-          - list
-          - create
-          - update
-          - delete
-          - deletecollection
-          - patch
-          - watch
-        - apiGroups:
-          - image.openshift.io
-          resources:
-          - imagestreams
-          - imagestreamtags
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - image.openshift.io
-          resources:
-          - imagestreams/finalizers
-          - imagestreamtags/finalizers
-          verbs:
-          - get
-          - list
-          - create
-          - update
-          - delete
-          - deletecollection
-          - patch
-          - watch
-        - apiGroups:
-          - build.openshift.io
-          resources:
-          - buildconfigs
-          - builds
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - build.openshift.io
-          resources:
-          - buildconfigs/finalizers
-          - builds/finalizers
-          verbs:
-          - get
-          - list
-          - create
-          - update
-          - delete
-          - deletecollection
-          - patch
-          - watch
-        - apiGroups:
-          - build.openshift.io
-          resources:
-          - buildconfigs/instantiatebinary
-          verbs:
-          - create
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
-        serviceAccountName: logic-operator-rhel8-controller-manager
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - pods
+                - pods/exec
+                - services
+                - services/finalizers
+                - namespaces
+                - serviceaccounts
+                - persistentvolumeclaims
+                - secrets
+                - events
+                - deployments
+                - nodes
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - configmaps
+                - pods
+                - pods/exec
+                - services
+                - services/finalizers
+                - namespaces
+                - serviceaccounts
+                - persistentvolumeclaims
+                - secrets
+                - events
+                - deployments
+                - nodes
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - sonataflow.org
+              resources:
+                - sonataflowbuilds
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - sonataflow.org
+              resources:
+                - sonataflowbuilds/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - sonataflow.org
+              resources:
+                - sonataflowbuilds/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - sonataflow.org
+              resources:
+                - sonataflowplatforms
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - sonataflow.org
+              resources:
+                - sonataflowplatforms/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - sonataflow.org
+              resources:
+                - sonataflowplatforms/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - sonataflow.org
+              resources:
+                - sonataflows
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - sonataflow.org
+              resources:
+                - sonataflows/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - sonataflow.org
+              resources:
+                - sonataflows/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - route
+                - routes
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - route/finalizers
+                - routes/finalizers
+              verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - deletecollection
+                - patch
+                - watch
+            - apiGroups:
+                - image.openshift.io
+              resources:
+                - imagestreams
+                - imagestreamtags
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - image.openshift.io
+              resources:
+                - imagestreams/finalizers
+                - imagestreamtags/finalizers
+              verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - deletecollection
+                - patch
+                - watch
+            - apiGroups:
+                - build.openshift.io
+              resources:
+                - buildconfigs
+                - builds
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - build.openshift.io
+              resources:
+                - buildconfigs/finalizers
+                - builds/finalizers
+              verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - deletecollection
+                - patch
+                - watch
+            - apiGroups:
+                - build.openshift.io
+              resources:
+                - buildconfigs/instantiatebinary
+              verbs:
+                - create
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: logic-operator-rhel8-controller-manager
       deployments:
-      - label:
-          control-plane: controller-manager
-        name: logic-operator-rhel8-controller-manager
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              control-plane: controller-manager
-          strategy: {}
-          template:
-            metadata:
-              annotations:
-                kubectl.kubernetes.io/default-container: manager
-              labels:
+        - label:
+            control-plane: controller-manager
+          name: logic-operator-rhel8-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 control-plane: controller-manager
-            spec:
-              containers:
-              - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --secure-listen-address=0.0.0.0:8443
+                      - --upstream=http://127.0.0.1:8080/
+                      - --logtostderr=true
+                      - --v=0
+                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
+                    name: kube-rbac-proxy
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 5m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                  - args:
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=127.0.0.1:8080
+                      - --leader-elect
+                    command:
+                      - /usr/local/bin/manager
+                    env:
+                      - name: POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-operator-rhel8@sha256:24c2e62bff1f2f7e5579b990e44206ac019bd00f5ca546b069471fc1af34ed75
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
                 securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
-                - --leader-elect
-                command:
-                - /usr/local/bin/manager
-                env:
-                - name: POD_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-operator-rhel8:1.30.0
-                livenessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 8081
-                  initialDelaySeconds: 15
-                  periodSeconds: 20
-                name: manager
-                readinessProbe:
-                  httpGet:
-                    path: /readyz
-                    port: 8081
-                  initialDelaySeconds: 5
-                  periodSeconds: 10
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 10m
-                    memory: 64Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-              securityContext:
-                runAsNonRoot: true
-              serviceAccountName: logic-operator-rhel8-controller-manager
-              terminationGracePeriodSeconds: 10
+                  runAsNonRoot: true
+                serviceAccountName: logic-operator-rhel8-controller-manager
+                terminationGracePeriodSeconds: 10
       permissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-        serviceAccountName: logic-operator-rhel8-controller-manager
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: logic-operator-rhel8-controller-manager
     strategy: deployment
   installModes:
-  - supported: false
-    type: OwnNamespace
-  - supported: false
-    type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
-  - supported: true
-    type: AllNamespaces
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
   keywords:
-  - sonataflow
-  - cncf
-  - serverless
-  - serverlessworkflow
+    - sonataflow
+    - cncf
+    - serverless
+    - serverlessworkflow
   links:
-  - name: Product Page
-    url: https://sonataflow.org/serverlessworkflow/latest/index.html
+    - name: Product Page
+      url: https://sonataflow.org/serverlessworkflow/latest/index.html
   maintainers:
-  - email: bsig-cloud@redhat.com
-    name: Red Hat
+    - email: bsig-cloud@redhat.com
+      name: Red Hat
   maturity: alpha
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
+  relatedImages:
+    - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:4564ca3dc5bac80d6faddaf94c817fbbc270698a9399d8a21ee1005d85ceda56
+      name: kube-rbac-proxy
+    - image: registry.redhat.io/openshift-serverless-1-tech-preview/logic-operator-rhel8@sha256:24c2e62bff1f2f7e5579b990e44206ac019bd00f5ca546b069471fc1af34ed75
+      name: manager
   version: 1.30.0

--- a/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
@@ -243,6 +243,10 @@ spec:
       - description: Flow the workflow definition.
         displayName: flow
         path: flow
+      - description: PodTemplate describes the deployment details of this SonataFlow
+          instance.
+        displayName: podTemplate
+        path: podTemplate
       - description: Resources workflow resources that are linked to this workflow
           definition. For example, a collection of OpenAPI specification files.
         displayName: resources

--- a/config/manager/osl/kustomization.yaml
+++ b/config/manager/osl/kustomization.yaml
@@ -18,9 +18,9 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:24c2e62bff1f2f7e5579b990e44206ac019bd00f5ca546b069471fc1af34ed75
-  name: controller
+- name: controller
   newName: registry.redhat.io/openshift-serverless-1-tech-preview/logic-operator-rhel8
+  newTag: 1.30.0
 # Patching the manager deployment file to add an env var with the operator namespace in
 patchesJson6902:
 - patch: |-

--- a/config/manager/osl/kustomization.yaml
+++ b/config/manager/osl/kustomization.yaml
@@ -18,9 +18,9 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
+- digest: sha256:24c2e62bff1f2f7e5579b990e44206ac019bd00f5ca546b069471fc1af34ed75
+  name: controller
   newName: registry.redhat.io/openshift-serverless-1-tech-preview/logic-operator-rhel8
-  newTag: 1.30.0
 # Patching the manager deployment file to add an env var with the operator namespace in
 patchesJson6902:
 - patch: |-

--- a/config/manifests/bases/sonataflow-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sonataflow-operator.clusterserviceversion.yaml
@@ -140,6 +140,10 @@ spec:
       - description: Flow the workflow definition.
         displayName: flow
         path: flow
+      - description: PodTemplate describes the deployment details of this SonataFlow
+          instance.
+        displayName: podTemplate
+        path: podTemplate
       - description: Resources workflow resources that are linked to this workflow
           definition. For example, a collection of OpenAPI specification files.
         displayName: resources

--- a/config/manifests/osl/bases/logic-operator-rhel8.clusterserviceversion.yaml
+++ b/config/manifests/osl/bases/logic-operator-rhel8.clusterserviceversion.yaml
@@ -141,6 +141,10 @@ spec:
       - description: Flow the workflow definition.
         displayName: flow
         path: flow
+      - description: PodTemplate describes the deployment details of this SonataFlow
+          instance.
+        displayName: podTemplate
+        path: podTemplate
       - description: Resources workflow resources that are linked to this workflow
           definition. For example, a collection of OpenAPI specification files.
         displayName: resources

--- a/controllers/profiles/common/object_creators.go
+++ b/controllers/profiles/common/object_creators.go
@@ -80,7 +80,7 @@ func DeploymentCreator(workflow *operatorapi.SonataFlow) (client.Object, error) 
 		},
 	}
 
-	if err := mergo.Merge(&deployment.Spec.Template.Spec, workflow.Spec.PodTemplate.PodSpec.ToPodSpec(), mergo.WithOverride); err != nil {
+	if err := mergo.Merge(&deployment.Spec.Template.Spec, workflow.Spec.PodTemplate.FlowPodSpec.ToPodSpec(), mergo.WithOverride); err != nil {
 		return nil, err
 	}
 

--- a/controllers/profiles/common/object_creators_test.go
+++ b/controllers/profiles/common/object_creators_test.go
@@ -96,7 +96,7 @@ func TestMergePodSpec(t *testing.T) {
 				{Name: "myvolume", ReadOnly: true, MountPath: "/tmp/any/path"},
 			},
 		},
-		PodSpec: v1alpha08.FlowPodSpec{
+		FlowPodSpec: v1alpha08.FlowPodSpec{
 			ServiceAccountName: "superuser",
 			Containers: []corev1.Container{
 				{
@@ -134,7 +134,7 @@ func TestMergePodSpec(t *testing.T) {
 func TestMergePodSpec_OverrideContainers(t *testing.T) {
 	workflow := test.GetBaseSonataFlow(t.Name())
 	workflow.Spec.PodTemplate = v1alpha08.FlowPodTemplateSpec{
-		PodSpec: v1alpha08.FlowPodSpec{
+		FlowPodSpec: v1alpha08.FlowPodSpec{
 			// Try to override the workflow container via the podspec
 			Containers: []corev1.Container{
 				{

--- a/hack/local/run-e2e.sh
+++ b/hack/local/run-e2e.sh
@@ -19,7 +19,7 @@ MINIKUBE_PROFILE=${1:-minikube}
 echo "Using minikube profile ${MINIKUBE_PROFILE}"
 
 # clean up previous runs
-make undeploy
+make undeploy ignore-not-found=true
 
 export OPERATOR_IMAGE_NAME=localhost/kogito-serverless-operator:0.0.1
 eval "$(minikube -p "${MINIKUBE_PROFILE}" docker-env)"

--- a/hack/local/run-operator.sh
+++ b/hack/local/run-operator.sh
@@ -15,9 +15,13 @@
 
 # Runs the operator locally via go main
 
-kubectl apply -f ./bundle/manifests/sonataflow.org_sonataflowplatforms.yaml
-kubectl apply -f ./bundle/manifests/sonataflow.org_sonataflowbuilds.yaml
-kubectl apply -f ./bundle/manifests/sonataflow.org_sonataflows.yaml
+kubectl delete --ignore-not-found=true -f ./bundle/manifests/sonataflow.org_sonataflowplatforms.yaml
+kubectl delete --ignore-not-found=true -f ./bundle/manifests/sonataflow.org_sonataflowbuilds.yaml
+kubectl delete --ignore-not-found=true -f ./bundle/manifests/sonataflow.org_sonataflows.yaml
+
+kubectl create -f ./bundle/manifests/sonataflow.org_sonataflowplatforms.yaml
+kubectl create -f ./bundle/manifests/sonataflow.org_sonataflowbuilds.yaml
+kubectl create -f ./bundle/manifests/sonataflow.org_sonataflows.yaml
 kubectl apply -f ./bundle/manifests/sonataflow-operator-builder-config_v1_configmap.yaml
 
 make debug


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
In this PR, we fix the `podTemplate` struct to include json inline serializable annotations.


**Motivation for the change:**
See https://issues.redhat.com/browse/KOGITO-9857

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>