### PR TITLE
[KOGITO-9890] Generate safe volume naming based on DNS 1035

### DIFF
--- a/controllers/profiles/dev/object_creators_dev.go
+++ b/controllers/profiles/dev/object_creators_dev.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kiegroup/kogito-serverless-operator/controllers/profiles"
 	"github.com/kiegroup/kogito-serverless-operator/controllers/profiles/common"
 	"github.com/kiegroup/kogito-serverless-operator/controllers/workflowdef"
-	"github.com/kiegroup/kogito-serverless-operator/utils"
 	kubeutil "github.com/kiegroup/kogito-serverless-operator/utils/kubernetes"
 	"github.com/kiegroup/kogito-serverless-operator/workflowproj"
 )
@@ -139,7 +138,7 @@ func mountDevConfigMapsMutateVisitor(flowDefCM, propsCM *corev1.ConfigMap, workf
 				}
 				// the resource configMap needs a specific dir, inside the src/main/resources
 				// to avoid clashing with other configMaps trying to mount on the same dir, we create one projected per path
-				volumeMountName := configMapExternalResourcesVolumeNamePrefix + utils.PathToString(workflowResCM.WorkflowPath)
+				volumeMountName := kubeutil.MustSafeDNS1035(configMapExternalResourcesVolumeNamePrefix, workflowResCM.WorkflowPath)
 				volumeMounts = kubeutil.VolumeMountAdd(volumeMounts, volumeMountName, path.Join(quarkusDevConfigMountPath, workflowResCM.WorkflowPath))
 				resourceVolumes = kubeutil.VolumeAddVolumeProjectionConfigMap(resourceVolumes, workflowResCM.ConfigMap.Name, volumeMountName)
 			}

--- a/controllers/profiles/dev/profile_dev_test.go
+++ b/controllers/profiles/dev/profile_dev_test.go
@@ -16,12 +16,10 @@ package dev
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kubeutil "github.com/kiegroup/kogito-serverless-operator/utils/kubernetes"
@@ -388,14 +386,9 @@ func Test_VolumeWithCapitalizedPaths(t *testing.T) {
 	assert.NotNil(t, deployment)
 
 	container, _ := kubeutil.GetContainerByName(operatorapi.DefaultContainerName, &deployment.Spec.Template.Spec)
-	assert.NoError(t, func() error {
-		for _, v := range container.VolumeMounts {
-			if errs := validation.NameIsDNS1035Label(v.Name, false); len(errs) > 0 {
-				return fmt.Errorf("failed to validate name %s. Errors: %v", v.Name, errs)
-			}
-		}
-		return nil
-	}())
+	// properties, definitions, and the capitalized value
+	assert.Len(t, container.VolumeMounts, 2)
+	assert.Len(t, deployment.Spec.Template.Spec.Volumes, 2)
 }
 
 func sortVolumeMounts(container *v1.Container) {

--- a/controllers/profiles/dev/states_dev.go
+++ b/controllers/profiles/dev/states_dev.go
@@ -38,8 +38,7 @@ import (
 
 const (
 	configMapResourcesVolumeName               = "resources"
-	configMapExternalResourcesVolumeNamePrefix = configMapResourcesVolumeName + "-"
-
+	configMapExternalResourcesVolumeNamePrefix = "res-"
 	// quarkusDevConfigMountPath mount path for application properties file in the Workflow Quarkus Application
 	// See: https://quarkus.io/guides/config-reference#application-properties-file
 	quarkusDevConfigMountPath = "/home/kogito/serverless-workflow-project/src/main/resources"

--- a/test/testdata/sonataflow.org_v1alpha08_sonataflow-metainf.yaml
+++ b/test/testdata/sonataflow.org_v1alpha08_sonataflow-metainf.yaml
@@ -1,0 +1,62 @@
+# Copyright 2023 Red Hat, Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: greeting
+  annotations:
+    sonataflow.org/description: Greeting example on k8s!
+    sonataflow.org/version: 0.0.1
+    sonataflow.org/profile: dev
+spec:
+  resources:
+    configMaps:
+      - configMap:
+          name: greetings-staticfiles
+        workflowPath: META-INF/resources
+  flow:
+    start: ChooseOnLanguage
+    functions:
+      - name: greetFunction
+        type: custom
+        operation: sysout
+    states:
+      - name: ChooseOnLanguage
+        type: switch
+        dataConditions:
+          - condition: "${ .language == \"English\" }"
+            transition: GreetInEnglish
+          - condition: "${ .language == \"Spanish\" }"
+            transition: GreetInSpanish
+        defaultCondition: GreetInEnglish
+      - name: GreetInEnglish
+        type: inject
+        data:
+          greeting: "Hello from JSON Workflow, "
+        transition: GreetPerson
+      - name: GreetInSpanish
+        type: inject
+        data:
+          greeting: "Saludos desde JSON Workflow, "
+        transition: GreetPerson
+      - name: GreetPerson
+        type: operation
+        actions:
+          - name: greetAction
+            functionRef:
+              refName: greetFunction
+              arguments:
+                message:  ".greeting+.name"
+        end: true

--- a/test/testdata/v1_configmap_greetings_staticfiles.yaml
+++ b/test/testdata/v1_configmap_greetings_staticfiles.yaml
@@ -1,0 +1,24 @@
+# Copyright 2023 Red Hat, Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: greetings-staticfiles
+data:
+  index.html: |-
+    <html>
+        <title>Greetings!</title>
+        <body>Greetings stranger!</body>
+    </html>

--- a/utils/kubernetes/naming.go
+++ b/utils/kubernetes/naming.go
@@ -1,0 +1,49 @@
+// Copyright 2023 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+const dns1035MaxChar int = 63
+
+// SafeDNS1035 generates a safe encoded string based on "s" with the given prefix.
+// Ideally used with internal generated names.
+//
+// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
+func SafeDNS1035(prefix, s string) (string, error) {
+	safeNaming := prefix + rand.SafeEncodeString(s)
+	if len(safeNaming) > dns1035MaxChar {
+		safeNaming = safeNaming[:dns1035MaxChar]
+	}
+	errMsgs := validation.NameIsDNS1035Label(safeNaming, false)
+	if len(errMsgs) > 0 {
+		return "", fmt.Errorf("failed to generate a safe name for %s with prefix %s: %v", s, prefix, errMsgs)
+	}
+	return safeNaming, nil
+}
+
+// MustSafeDNS1035 see SafeDNS1035. Use this function only if you control the prefix.
+func MustSafeDNS1035(prefix, s string) string {
+	name, err := SafeDNS1035(prefix, s)
+	if err != nil {
+		panic(err)
+	}
+	return name
+}

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -15,8 +15,6 @@
 package utils
 
 import (
-	"os"
-	"path"
 	"strings"
 )
 
@@ -32,9 +30,4 @@ func RemoveKnownExtension(fileName, extension string) string {
 		return fileName[:i]
 	}
 	return fileName
-}
-
-// PathToString replaces the PathSeparator from a given path.
-func PathToString(pathRef string) string {
-	return strings.ReplaceAll(path.Clean(pathRef), string(os.PathSeparator), "")
 }


### PR DESCRIPTION
**Description of the change:**
In this PR, we safely generate volume naming for the dev profile resources to avoid problems with mount paths like `META-INF/resources`.

**Motivation for the change:**
See https://issues.redhat.com/browse/KOGITO-9890

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>