### PR TITLE
[KOGITO-9908] Fix reconciliation to always ensure prod objects

### DIFF
--- a/controllers/profiles/common/deployment.go
+++ b/controllers/profiles/common/deployment.go
@@ -88,7 +88,7 @@ func (d deploymentHandler) SyncDeploymentStatus(ctx context.Context, workflow *o
 
 	workflow.Status.Manager().MarkFalse(api.RunningConditionType, api.WaitingForDeploymentReason, "")
 	klog.V(log.I).InfoS("Workflow is in WaitingForDeployment Condition")
-	return ctrl.Result{RequeueAfter: RequeueAfterFollowDeployment}, nil
+	return ctrl.Result{RequeueAfter: RequeueAfterFollowDeployment, Requeue: true}, nil
 }
 
 // GetDeploymentUnavailabilityMessage gets the replica failure reason.

--- a/controllers/profiles/common/ensurer.go
+++ b/controllers/profiles/common/ensurer.go
@@ -17,10 +17,8 @@ package common
 import (
 	"context"
 
-	"k8s.io/klog/v2"
-
 	"github.com/apache/incubator-kie-kogito-serverless-operator/log"
-
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 

--- a/controllers/profiles/common/object_creators.go
+++ b/controllers/profiles/common/object_creators.go
@@ -67,7 +67,7 @@ func DeploymentCreator(workflow *operatorapi.SonataFlow) (client.Object, error) 
 			Labels:    lbl,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: workflow.Spec.PodTemplate.Replicas,
+			Replicas: getReplicasOrDefault(workflow),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: lbl,
 			},
@@ -91,6 +91,14 @@ func DeploymentCreator(workflow *operatorapi.SonataFlow) (client.Object, error) 
 	kubeutil.AddOrReplaceContainer(operatorapi.DefaultContainerName, *flowContainer, &deployment.Spec.Template.Spec)
 
 	return deployment, nil
+}
+
+func getReplicasOrDefault(workflow *operatorapi.SonataFlow) *int32 {
+	var dReplicas int32 = 1
+	if workflow.Spec.PodTemplate.Replicas == nil {
+		return &dReplicas
+	}
+	return workflow.Spec.PodTemplate.Replicas
 }
 
 func defaultContainer(workflow *operatorapi.SonataFlow) (*corev1.Container, error) {

--- a/controllers/profiles/dev/profile_dev_test.go
+++ b/controllers/profiles/dev/profile_dev_test.go
@@ -47,7 +47,7 @@ import (
 func Test_OverrideStartupProbe(t *testing.T) {
 	workflow := test.GetBaseSonataFlow(t.Name())
 
-	client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
+	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
 
 	devReconciler := NewProfileReconciler(client)
 
@@ -74,7 +74,7 @@ func Test_recoverFromFailureNoDeployment(t *testing.T) {
 	workflowID := clientruntime.ObjectKeyFromObject(workflow)
 
 	workflow.Status.Manager().MarkFalse(api.RunningConditionType, api.DeploymentFailureReason, "")
-	client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
+	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
 
 	reconciler := NewProfileReconciler(client)
 
@@ -115,7 +115,7 @@ func Test_recoverFromFailureNoDeployment(t *testing.T) {
 func Test_newDevProfile(t *testing.T) {
 	workflow := test.GetBaseSonataFlow(t.Name())
 
-	client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
+	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
 
 	devReconciler := NewProfileReconciler(client)
 
@@ -189,7 +189,7 @@ func Test_newDevProfile(t *testing.T) {
 
 func Test_devProfileImageDefaultsNoPlatform(t *testing.T) {
 	workflow := test.GetBaseSonataFlowWithDevProfile(t.Name())
-	client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
+	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
 	devReconciler := NewProfileReconciler(client)
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
@@ -206,7 +206,7 @@ func Test_devProfileWithImageSnapshotOverrideWithPlatform(t *testing.T) {
 
 	platform := test.GetBasePlatformWithDevBaseImageInReadyPhase(workflow.Namespace)
 
-	client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow, platform).WithStatusSubresource(workflow, platform).Build()
+	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, platform).WithStatusSubresource(workflow, platform).Build()
 	devReconciler := NewProfileReconciler(client)
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
@@ -223,7 +223,7 @@ func Test_devProfileWithWPlatformWithoutDevBaseImageAndWithBaseImage(t *testing.
 
 	platform := test.GetBasePlatformWithBaseImageInReadyPhase(workflow.Namespace)
 
-	client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow, platform).WithStatusSubresource(workflow, platform).Build()
+	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, platform).WithStatusSubresource(workflow, platform).Build()
 	devReconciler := NewProfileReconciler(client)
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
@@ -240,7 +240,7 @@ func Test_devProfileWithPlatformWithoutDevBaseImageAndWithoutBaseImage(t *testin
 
 	platform := test.GetBasePlatformInReadyPhase(workflow.Namespace)
 
-	client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow, platform).WithStatusSubresource(workflow, platform).Build()
+	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, platform).WithStatusSubresource(workflow, platform).Build()
 	devReconciler := NewProfileReconciler(client)
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
@@ -258,7 +258,7 @@ func Test_newDevProfileWithExternalConfigMaps(t *testing.T) {
 	workflow.Spec.Resources.ConfigMaps = append(workflow.Spec.Resources.ConfigMaps,
 		operatorapi.ConfigMapWorkflowResource{ConfigMap: v1.LocalObjectReference{Name: configmapName}, WorkflowPath: "routes"})
 
-	client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
+	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
 
 	devReconciler := NewProfileReconciler(client)
 
@@ -374,7 +374,7 @@ func Test_VolumeWithCapitalizedPaths(t *testing.T) {
 	configMap.Namespace = t.Name()
 	workflow := test.GetSonataFlow(test.SonataFlowGreetingsWithStaticResourcesCR, t.Name())
 
-	client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow, configMap).WithStatusSubresource(workflow, configMap).Build()
+	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, configMap).WithStatusSubresource(workflow, configMap).Build()
 
 	devReconciler := NewProfileReconciler(client)
 

--- a/controllers/profiles/dev/status_enricher_dev_test.go
+++ b/controllers/profiles/dev/status_enricher_dev_test.go
@@ -35,7 +35,7 @@ func Test_enrichmentStatusOnK8s(t *testing.T) {
 		workflow := test.GetBaseSonataFlowWithDevProfile(t.Name())
 		workflow.Namespace = toK8SNamespace(t.Name())
 		service, err := common.ServiceCreator(workflow)
-		client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow, service).Build()
+		client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, service).Build()
 		obj, err := statusEnricher(context.TODO(), client, workflow)
 
 		reflectWorkflow := obj.(*apiv08.SonataFlow)
@@ -51,7 +51,7 @@ func Test_enrichmentStatusOnK8s(t *testing.T) {
 		workflow := test.GetBaseSonataFlowWithDevProfile(t.Name())
 		workflow.Namespace = t.Name()
 		service, err := serviceCreator(workflow)
-		client := test.NewKogitoClientBuilder().WithRuntimeObjects(workflow, service).Build()
+		client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, service).Build()
 		_, err = statusEnricher(context.TODO(), client, workflow)
 		assert.Error(t, err)
 

--- a/controllers/profiles/prod/deployment_handler_test.go
+++ b/controllers/profiles/prod/deployment_handler_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/test"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+func Test_CheckPodTemplateChangesReflectDeployment(t *testing.T) {
+	workflow := test.GetBaseSonataFlowWithProdOpsProfile(t.Name())
+
+	client := test.NewSonataFlowClientBuilder().
+		WithRuntimeObjects(workflow).
+		WithStatusSubresource(workflow).
+		Build()
+	stateSupport := fakeReconcilerSupport(client)
+	handler := newDeploymentHandler(stateSupport, newObjectEnsurers(stateSupport))
+
+	result, objects, err := handler.handle(context.TODO(), workflow)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, objects)
+	assert.True(t, result.Requeue)
+
+	// Second reconciliation, we do change the image and that must reflect the deployment
+	expectedImg := "quay.io/apache/my-new-workflow:1.0.0"
+	workflow.Spec.PodTemplate.Container.Image = expectedImg
+	utilruntime.Must(client.Update(context.TODO(), workflow))
+	result, objects, err = handler.handle(context.TODO(), workflow)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, objects)
+	assert.True(t, result.Requeue)
+	for _, o := range objects {
+		if _, ok := o.(*v1.Deployment); ok {
+			deployment := o.(*v1.Deployment)
+			assert.Equal(t, expectedImg, deployment.Spec.Template.Spec.Containers[0].Image)
+			assert.Equal(t, v1alpha08.DefaultContainerName, deployment.Spec.Template.Spec.Containers[0].Name)
+			break
+		}
+	}
+
+	// Nothing changes, requeue == false
+	result, objects, err = handler.handle(context.TODO(), workflow)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, objects)
+	assert.False(t, result.Requeue)
+}

--- a/controllers/profiles/prod/deployment_handler_test.go
+++ b/controllers/profiles/prod/deployment_handler_test.go
@@ -56,10 +56,4 @@ func Test_CheckPodTemplateChangesReflectDeployment(t *testing.T) {
 			break
 		}
 	}
-
-	// Nothing changes, requeue == false
-	result, objects, err = handler.handle(context.TODO(), workflow)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, objects)
-	assert.False(t, result.Requeue)
 }

--- a/controllers/profiles/prod/profile_prod_test.go
+++ b/controllers/profiles/prod/profile_prod_test.go
@@ -39,7 +39,7 @@ func Test_Reconciler_ProdOps(t *testing.T) {
 		Image:   "registry.access.redhat.com/ubi9/ubi-minimal:latest",
 		Command: []string{"sh", "-c", "until (echo 1 > /dev/tcp/postgres.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/5432) >/dev/null 2>&1; do echo \"Waiting for postgres server\"; sleep 3; done;"},
 	})
-	client := test.NewKogitoClientBuilder().
+	client := test.NewSonataFlowClientBuilder().
 		WithRuntimeObjects(workflow).
 		WithStatusSubresource(workflow, &operatorapi.SonataFlowBuild{}).Build()
 	result, err := NewProfileForOpsReconciler(client).Reconcile(context.TODO(), workflow)
@@ -78,7 +78,7 @@ func Test_Reconciler_ProdCustomPod(t *testing.T) {
 	workflow.Status.Manager().MarkTrue(api.RunningConditionType)
 	build := test.GetLocalSucceedSonataFlowBuild(workflow.Name, workflow.Namespace)
 	platform := test.GetBasePlatformInReadyPhase(workflow.Namespace)
-	client := test.NewKogitoClientBuilder().
+	client := test.NewSonataFlowClientBuilder().
 		WithRuntimeObjects(workflow, build, platform).
 		WithStatusSubresource(workflow, build, platform).Build()
 	_, err := NewProfileReconciler(client).Reconcile(context.TODO(), workflow)
@@ -98,7 +98,7 @@ func Test_Reconciler_ProdCustomPod(t *testing.T) {
 func Test_reconcilerProdBuildConditions(t *testing.T) {
 	workflow := test.GetBaseSonataFlow(t.Name())
 	platform := test.GetBasePlatformInReadyPhase(t.Name())
-	client := test.NewKogitoClientBuilder().
+	client := test.NewSonataFlowClientBuilder().
 		WithRuntimeObjects(workflow, platform).
 		WithStatusSubresource(workflow, platform, &operatorapi.SonataFlowBuild{}).Build()
 
@@ -159,7 +159,7 @@ func Test_deployWorkflowReconciliationHandler_handleObjects(t *testing.T) {
 	workflow := test.GetBaseSonataFlow(t.Name())
 	platform := test.GetBasePlatformInReadyPhase(t.Name())
 	build := test.GetLocalSucceedSonataFlowBuild(workflow.Name, workflow.Namespace)
-	client := test.NewKogitoClientBuilder().
+	client := test.NewSonataFlowClientBuilder().
 		WithRuntimeObjects(workflow, platform, build).
 		WithStatusSubresource(workflow, platform, build).
 		Build()
@@ -206,7 +206,7 @@ func Test_GenerationAnnotationCheck(t *testing.T) {
 	// we load a workflow with metadata.generation to 0
 	workflow := test.GetBaseSonataFlow(t.Name())
 	platform := test.GetBasePlatformInReadyPhase(t.Name())
-	client := test.NewKogitoClientBuilder().
+	client := test.NewSonataFlowClientBuilder().
 		WithRuntimeObjects(workflow, platform).
 		WithStatusSubresource(workflow, platform, &operatorapi.SonataFlowBuild{}).Build()
 

--- a/controllers/sonataflow_controller_test.go
+++ b/controllers/sonataflow_controller_test.go
@@ -42,7 +42,7 @@ func TestSonataFlowController(t *testing.T) {
 		objs := []runtime.Object{ksw, ksp}
 
 		// Create a fake client to mock API calls.
-		cl := test.NewKogitoClientBuilder().WithRuntimeObjects(objs...).WithStatusSubresource(ksw, ksp).Build()
+		cl := test.NewSonataFlowClientBuilder().WithRuntimeObjects(objs...).WithStatusSubresource(ksw, ksp).Build()
 		// Create a SonataFlowReconciler object with the scheme and fake client.
 		r := &SonataFlowReconciler{Client: cl, Scheme: cl.Scheme()}
 

--- a/controllers/sonataflowbuild_controller_test.go
+++ b/controllers/sonataflowbuild_controller_test.go
@@ -35,7 +35,7 @@ func TestSonataFlowBuildController(t *testing.T) {
 	ksw := test.GetBaseSonataFlow(namespace)
 	ksb := test.GetNewEmptySonataFlowBuild(ksw.Name, namespace)
 
-	cl := test.NewKogitoClientBuilder().
+	cl := test.NewSonataFlowClientBuilder().
 		WithRuntimeObjects(ksb, ksw).
 		WithRuntimeObjects(test.GetBasePlatformInReadyPhase(namespace)).
 		WithRuntimeObjects(test.GetSonataFlowBuilderConfig(namespace)).
@@ -77,7 +77,7 @@ func TestSonataFlowBuildController_WithArgsAndEnv(t *testing.T) {
 		Value: "extension1,extension2",
 	}
 
-	cl := test.NewKogitoClientBuilder().
+	cl := test.NewSonataFlowClientBuilder().
 		WithRuntimeObjects(ksb, ksw).
 		WithRuntimeObjects(test.GetBasePlatformInReadyPhase(namespace)).
 		WithRuntimeObjects(test.GetSonataFlowBuilderConfig(namespace)).

--- a/controllers/sonataflowplatform_controller_test.go
+++ b/controllers/sonataflowplatform_controller_test.go
@@ -35,7 +35,7 @@ func TestSonataFlowPlatformController(t *testing.T) {
 		ksp := test.GetBasePlatform()
 
 		// Create a fake client to mock API calls.
-		cl := test.NewKogitoClientBuilder().WithRuntimeObjects(ksp).WithStatusSubresource(ksp).Build()
+		cl := test.NewSonataFlowClientBuilder().WithRuntimeObjects(ksp).WithStatusSubresource(ksp).Build()
 		// Create a SonataFlowPlatformReconciler object with the scheme and fake client.
 		r := &SonataFlowPlatformReconciler{cl, cl, cl.Scheme(), &rest.Config{}, &record.FakeRecorder{}}
 

--- a/test/kubernetes_cli.go
+++ b/test/kubernetes_cli.go
@@ -33,8 +33,8 @@ import (
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 )
 
-// NewKogitoClientBuilder creates a new fake.ClientBuilder with the right scheme references
-func NewKogitoClientBuilder() *fake.ClientBuilder {
+// NewSonataFlowClientBuilder creates a new fake.ClientBuilder with the right scheme references
+func NewSonataFlowClientBuilder() *fake.ClientBuilder {
 	s := scheme.Scheme
 	utilruntime.Must(operatorapi.AddToScheme(s))
 	return fake.NewClientBuilder().WithScheme(s)

--- a/test/yaml.go
+++ b/test/yaml.go
@@ -171,6 +171,7 @@ func GetBaseSonataFlowWithProdProfile(namespace string) *operatorapi.SonataFlow 
 	return workflow
 }
 
+// GetBaseSonataFlowWithProdOpsProfile gets a base workflow that has a pre-built image set in podTemplate.
 func GetBaseSonataFlowWithProdOpsProfile(namespace string) *operatorapi.SonataFlow {
 	workflow := GetSonataFlow(SonataFlowSimpleOpsYamlCR, namespace)
 	return workflow

--- a/utils/kubernetes/naming_test.go
+++ b/utils/kubernetes/naming_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustSafeDNS1035_EnsureEquality(t *testing.T) {
+	s1 := MustSafeDNS1035("prefix-", "bananas")
+	s2 := MustSafeDNS1035("prefix-", "bananas")
+	assert.Equal(t, s1, s2)
+}


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
In this PR, we fixed a critical bug where the controller won't update the podTemplate accordingly, making the GitOps use case unavailable.

**Motivation for the change:**
See https://issues.redhat.com/browse/KOGITO-9908

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>