### PR TITLE
[KOGITO-8524] Enable toggle dev/prod profiles

### DIFF
--- a/api/v1alpha08/sonataflow_types.go
+++ b/api/v1alpha08/sonataflow_types.go
@@ -716,6 +716,11 @@ func (s *SonataFlowStatus) IsBuildRunningOrUnknown() bool {
 	return cond.IsUnknown() || (cond.IsFalse() && cond.Reason == api.BuildIsRunningReason)
 }
 
+func (s *SonataFlowStatus) IsBuildRunning() bool {
+	cond := s.GetCondition(api.BuiltConditionType)
+	return cond.IsFalse() && cond.Reason == api.BuildIsRunningReason
+}
+
 func (s *SonataFlowStatus) IsBuildFailed() bool {
 	cond := s.GetCondition(api.BuiltConditionType)
 	return cond.IsFalse() && cond.Reason == api.BuildFailedReason

--- a/controllers/builder/kogitoserverlessbuild_manager.go
+++ b/controllers/builder/kogitoserverlessbuild_manager.go
@@ -67,7 +67,7 @@ func (k *sonataFlowBuildManager) GetOrCreateBuild(workflow *operatorapi.SonataFl
 type SonataFlowBuildManager interface {
 	// GetOrCreateBuild gets or creates a new instance of SonataFlowBuild for the given SonataFlow.
 	//
-	// Only one build is allowed per workflow instance
+	// Only one build is allowed per workflow instance.
 	GetOrCreateBuild(workflow *operatorapi.SonataFlow) (*operatorapi.SonataFlowBuild, error)
 	// MarkToRestart tell the controller to restart this build in the next iteration
 	MarkToRestart(build *operatorapi.SonataFlowBuild) error

--- a/controllers/platform/initialize.go
+++ b/controllers/platform/initialize.go
@@ -156,7 +156,7 @@ func (action *initializeAction) isPrimaryDuplicate(ctx context.Context, thisPlat
 		// Always reconcile secondary platforms
 		return false, nil
 	}
-	platforms, err := ListPrimaryPlatforms(ctx, action.client, thisPlatform.Namespace)
+	platforms, err := listPrimaryPlatforms(ctx, action.client, thisPlatform.Namespace)
 	if err != nil {
 		return false, err
 	}

--- a/controllers/platform/platformutils.go
+++ b/controllers/platform/platformutils.go
@@ -42,7 +42,7 @@ var builderDockerfileFromRE = regexp.MustCompile(`FROM (.*) AS builder`)
 // ResourceCustomizer can be used to inject code that changes the objects before they are created.
 type ResourceCustomizer func(object ctrl.Object) ctrl.Object
 
-func ConfigureRegistry(ctx context.Context, c client.Client, p *operatorapi.SonataFlowPlatform, verbose bool) error {
+func configureRegistry(ctx context.Context, c client.Client, p *operatorapi.SonataFlowPlatform, verbose bool) error {
 	if p.Spec.Build.Config.BuildStrategy == operatorapi.PlatformBuildStrategy && p.Status.Cluster == operatorapi.PlatformClusterOpenShift {
 		p.Spec.Build.Config.Registry = operatorapi.RegistrySpec{}
 		klog.V(log.D).InfoS("Platform registry not set and ignored on openshift cluster")
@@ -63,7 +63,7 @@ func ConfigureRegistry(ctx context.Context, c client.Client, p *operatorapi.Sona
 	return nil
 }
 
-func SetPlatformDefaults(p *operatorapi.SonataFlowPlatform, verbose bool) error {
+func setPlatformDefaults(p *operatorapi.SonataFlowPlatform, verbose bool) error {
 	if p.Spec.Build.Config.BuildStrategyOptions == nil {
 		klog.V(log.D).InfoS("SonataFlow Platform: setting publish strategy options", "namespace", p.Namespace)
 		p.Spec.Build.Config.BuildStrategyOptions = map[string]string{}

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -171,16 +171,6 @@ var _ = Describe("SonataFlow Operator", Ordered, func() {
 	Describe("ensure that Operator and Operand(s) can run in restricted namespaces", func() {
 		projectDir, _ := utils.GetProjectDir()
 
-		It("should create a basic platform for Minikube", func() {
-			By("creating an instance of the SonataFlowPlatform")
-			EventuallyWithOffset(1, func() error {
-				cmd := exec.Command("kubectl", "apply", "-f", filepath.Join(projectDir,
-					getSonataFlowPlatformFilename()), "-n", namespace)
-				_, err := utils.Run(cmd)
-				return err
-			}, time.Minute, time.Second).Should(Succeed())
-		})
-
 		It("should successfully deploy the Simple Workflow in prod ops mode and verify if it's running", func() {
 			By("creating an instance of the SonataFlow Operand(CR)")
 			EventuallyWithOffset(1, func() error {


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
In this PR, we stabilize the use case to switch between prod and dev profiles in the `SonataFlow` CR instances.
Also, we've added the possibility to make the controller create a new default platform if none is found.

**Motivation for the change:**
See https://issues.redhat.com/browse/KOGITO-8524

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>