### PR TITLE
[KOGITO-9924] use AppPropertyHandler for Data Index custom properties

### DIFF
--- a/controllers/profiles/common/app_properties.go
+++ b/controllers/profiles/common/app_properties.go
@@ -30,6 +30,7 @@ const (
 	kogitoServiceUrlProperty         = "kogito.service.url"
 	kogitoServiceUrlProtocol         = "http"
 	dataIndexServiceUrlProperty      = "mp.messaging.outgoing.kogito-processinstances-events.url"
+	kafkaSmallRyeHealthProperty      = "quarkus.smallrye-health.check.\"io.quarkus.kafka.client.health.KafkaHealthCheck\".enabled"
 	dataIndexServiceUrlProtocol      = "http"
 
 	DataIndexImageBase = "quay.io/kiegroup/kogito-data-index-"
@@ -59,6 +60,7 @@ type appPropertyHandler struct {
 	platform                 *operatorapi.SonataFlowPlatform
 	userProperties           string
 	defaultMutableProperties string
+	isService                bool
 }
 
 func (a *appPropertyHandler) WithUserProperties(properties string) AppPropertyHandler {
@@ -76,7 +78,11 @@ func (a *appPropertyHandler) Build() string {
 	}
 	if propErr != nil {
 		// can't load user's properties, ignore it
-		klog.V(log.D).InfoS("Can't load user's property", "workflow", a.workflow.Name, "namespace", a.workflow.Namespace, "properties", a.userProperties)
+		if a.isService && a.platform != nil {
+			klog.V(log.D).InfoS("Can't load user's property", "platform", a.platform.Name, "namespace", a.platform.Namespace, "properties", a.userProperties)
+		} else {
+			klog.V(log.D).InfoS("Can't load user's property", "workflow", a.workflow.Name, "namespace", a.workflow.Namespace, "properties", a.userProperties)
+		}
 		props = properties.NewProperties()
 	}
 	// Disable expansions since it's not our responsibility
@@ -121,6 +127,16 @@ func (a *appPropertyHandler) withDataIndexServiceUrl() AppPropertyHandler {
 	return a
 }
 
+// withKafkaHealthCheckDisabled adds the property kafkaSmallRyeHealthProperty to the application properties.
+// See Service Discovery https://kubernetes.io/docs/concepts/services-networking/service/#dns
+func (a *appPropertyHandler) withKafkaHealthCheckDisabled() AppPropertyHandler {
+	a.addDefaultMutableProperty(
+		kafkaSmallRyeHealthProperty,
+		"false",
+	)
+	return a
+}
+
 func (a *appPropertyHandler) addDefaultMutableProperty(name string, value string) AppPropertyHandler {
 	a.defaultMutableProperties = a.defaultMutableProperties + fmt.Sprintf("%s=%s\n", name, value)
 	return a
@@ -143,6 +159,17 @@ func NewAppPropertyHandler(workflow *operatorapi.SonataFlow, platform *operatora
 	return handler.withKogitoServiceUrl()
 }
 
+// NewServicePropertyHandler creates the default service configurations property handler
+// The set of properties is initialized with the operator provided immutable properties.
+// The set of defaultMutableProperties is initialized with the operator provided properties that the user might override.
+func NewServiceAppPropertyHandler(platform *operatorapi.SonataFlowPlatform) AppPropertyHandler {
+	handler := &appPropertyHandler{
+		platform:  platform,
+		isService: true,
+	}
+	return handler.withKafkaHealthCheckDisabled()
+}
+
 // ImmutableApplicationProperties immutable default application properties that can be used with any workflow based on Quarkus.
 // Alias for NewAppPropertyHandler(workflow).Build()
 func ImmutableApplicationProperties(workflow *operatorapi.SonataFlow, platform *operatorapi.SonataFlowPlatform) string {
@@ -151,4 +178,8 @@ func ImmutableApplicationProperties(workflow *operatorapi.SonataFlow, platform *
 
 func GetDataIndexName(platform *operatorapi.SonataFlowPlatform) string {
 	return platform.Name + "-" + DataIndexName
+}
+
+func GetDataIndexCmName(platform *operatorapi.SonataFlowPlatform) string {
+	return GetDataIndexName(platform) + "-props"
 }

--- a/controllers/profiles/common/app_properties_test.go
+++ b/controllers/profiles/common/app_properties_test.go
@@ -89,7 +89,7 @@ func Test_appPropertyHandler_WithServicesWithUserOverrides(t *testing.T) {
 	generatedProps, propsErr = properties.LoadString(props)
 	assert.NoError(t, propsErr)
 	assert.Equal(t, 9, len(generatedProps.Keys()))
-	assert.Equal(t, "http://"+platform.Name+"-data-index-service."+platform.Namespace+"/processes", generatedProps.GetString(dataIndexServiceUrlProperty, ""))
+	assert.Equal(t, "http://"+platform.Name+"-"+DataIndexName+"."+platform.Namespace+"/processes", generatedProps.GetString(dataIndexServiceUrlProperty, ""))
 
 	// disabling data index bypasses config of outgoing events url
 	platform.Spec.Services.DataIndex.Enabled = nil
@@ -98,4 +98,15 @@ func Test_appPropertyHandler_WithServicesWithUserOverrides(t *testing.T) {
 	assert.NoError(t, propsErr)
 	assert.Equal(t, 8, len(generatedProps.Keys()))
 	assert.Equal(t, "", generatedProps.GetString(dataIndexServiceUrlProperty, ""))
+
+	// check that service app properties are being properly set
+	props = NewServiceAppPropertyHandler(platform).WithUserProperties(userProperties).Build()
+	generatedProps, propsErr = properties.LoadString(props)
+	assert.NoError(t, propsErr)
+	assert.Equal(t, 9, len(generatedProps.Keys()))
+	assert.Equal(t, "false", generatedProps.GetString(kafkaSmallRyeHealthProperty, ""))
+	assert.Equal(t, "value1", generatedProps.GetString("property1", ""))
+	assert.Equal(t, "value2", generatedProps.GetString("property2", ""))
+	//quarkus.http.port remains with the default value since it's immutable.
+	assert.Equal(t, "8080", generatedProps.GetString("quarkus.http.port", ""))
 }


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
Leverage the `AppPropertyHandler` for Data Index custom properties.

**Motivation for the change:**
The operator should support custom application properties for Data Index, just as it does for workflow.

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>