### PR TITLE
[KOGITO-8792] - Add events to build controllers and the ability to restart a build

### DIFF
--- a/api/condition_types.go
+++ b/api/condition_types.go
@@ -51,7 +51,9 @@ const (
 	BuildFailedReason               = "BuildFailedReason"
 	WaitingForBuildReason           = "WaitingForBuild"
 	BuildIsRunningReason            = "BuildIsRunning"
-	BuildSkipped                    = "BuildSkipped"
+	BuildSkippedReason              = "BuildSkipped"
+	BuildSuccessfulReason           = "BuildSuccessful"
+	BuildMarkedToRestartReason      = "BuildMarkedToRestart"
 )
 
 // Condition describes the common structure for conditions in our types

--- a/api/status_types.go
+++ b/api/status_types.go
@@ -283,21 +283,12 @@ func (s *conditionManager) MarkUnknown(t ConditionType, reason, messageFormat st
 
 // MarkFalse sets the status of t and the ready condition to False.
 func (s *conditionManager) MarkFalse(t ConditionType, reason, messageFormat string, messageA ...interface{}) {
-	types := []ConditionType{t}
-	for _, cond := range s.dependents {
-		if cond == t {
-			types = append(types, s.ready)
-		}
-	}
-
-	for _, t := range types {
-		s.setCondition(Condition{
-			Type:    t,
-			Status:  corev1.ConditionFalse,
-			Reason:  reason,
-			Message: fmt.Sprintf(messageFormat, messageA...),
-		})
-	}
+	s.setCondition(Condition{
+		Type:    t,
+		Status:  corev1.ConditionFalse,
+		Reason:  reason,
+		Message: fmt.Sprintf(messageFormat, messageA...),
+	})
 }
 
 // InitializeConditions updates all Conditions in the ConditionSet to Unknown

--- a/api/v1alpha08/sonataflow_types.go
+++ b/api/v1alpha08/sonataflow_types.go
@@ -694,7 +694,7 @@ func (s *SonataFlowStatus) Manager() api.ConditionsManager {
 }
 
 func (s *SonataFlowStatus) IsWaitingForPlatform() bool {
-	cond := s.GetCondition(api.RunningConditionType)
+	cond := s.GetCondition(api.BuiltConditionType)
 	return cond.IsFalse() && cond.Reason == api.WaitingForPlatformReason
 }
 

--- a/api/v1alpha08/sonataflowbuild_types.go
+++ b/api/v1alpha08/sonataflowbuild_types.go
@@ -22,6 +22,7 @@ package v1alpha08
 import (
 	"encoding/json"
 
+	"github.com/apache/incubator-kie-kogito-serverless-operator/api/metadata"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,6 +50,9 @@ const (
 	// BuildPhaseError --
 	BuildPhaseError BuildPhase = "Error"
 )
+
+// BuildRestartAnnotation marks a SonataFlowBuild to restart
+const BuildRestartAnnotation = metadata.Domain + "/restartBuild"
 
 // BuildTemplate an abstraction over the actual build process performed by the platform.
 // +k8s:openapi-gen=true

--- a/controllers/builder/containerbuilder.go
+++ b/controllers/builder/containerbuilder.go
@@ -89,6 +89,9 @@ func (c *containerBuilderManager) Schedule(build *operatorapi.SonataFlowBuild) e
 		return err
 	}
 	build.Status.BuildPhase = operatorapi.BuildPhase(containerBuilder.Status.Phase)
+	if len(build.Status.BuildPhase) == 0 {
+		build.Status.BuildPhase = operatorapi.BuildPhaseInitialization
+	}
 	build.Status.Error = containerBuilder.Status.Error
 	return nil
 }

--- a/controllers/profiles/common/deployment.go
+++ b/controllers/profiles/common/deployment.go
@@ -36,18 +36,20 @@ import (
 	kubeutil "github.com/apache/incubator-kie-kogito-serverless-operator/utils/kubernetes"
 )
 
-var _ WorkflowDeploymentHandler = &deploymentHandler{}
+var _ WorkflowDeploymentManager = &deploymentHandler{}
 
-// WorkflowDeploymentHandler interface to handle workflow deployment features.
-type WorkflowDeploymentHandler interface {
+// WorkflowDeploymentManager interface to handle workflow deployment features.
+type WorkflowDeploymentManager interface {
 	// SyncDeploymentStatus updates the workflow status aligned with the deployment counterpart.
 	// For example, if the deployment is in a failed state, it sets the status to
 	// Running `false` and the Message and Reason to human-readable format.
 	SyncDeploymentStatus(ctx context.Context, workflow *operatorapi.SonataFlow) (ctrl.Result, error)
+	// RolloutDeployment rolls out the underlying deployment object for the given workflow.
+	RolloutDeployment(ctx context.Context, workflow *operatorapi.SonataFlow) error
 }
 
-// DeploymentHandler creates a new WorkflowDeploymentHandler implementation based on the current profile.
-func DeploymentHandler(c client.Client) WorkflowDeploymentHandler {
+// DeploymentManager creates a new WorkflowDeploymentManager implementation based on the current profile.
+func DeploymentManager(c client.Client) WorkflowDeploymentManager {
 	return &deploymentHandler{c: c}
 }
 
@@ -55,7 +57,15 @@ type deploymentHandler struct {
 	c client.Client
 }
 
-func (d deploymentHandler) SyncDeploymentStatus(ctx context.Context, workflow *operatorapi.SonataFlow) (ctrl.Result, error) {
+func (d *deploymentHandler) RolloutDeployment(ctx context.Context, workflow *operatorapi.SonataFlow) error {
+	deployment := &appsv1.Deployment{}
+	if err := d.c.Get(ctx, client.ObjectKeyFromObject(workflow), deployment); err != nil {
+		return kubeutil.MarkDeploymentToRollout(deployment)
+	}
+	return nil
+}
+
+func (d *deploymentHandler) SyncDeploymentStatus(ctx context.Context, workflow *operatorapi.SonataFlow) (ctrl.Result, error) {
 	deployment := &appsv1.Deployment{}
 	if err := d.c.Get(ctx, client.ObjectKeyFromObject(workflow), deployment); err != nil {
 		// we should have the deployment by this time, so even if the error above is not found, we should halt.

--- a/controllers/profiles/dev/profile_dev.go
+++ b/controllers/profiles/dev/profile_dev.go
@@ -21,6 +21,7 @@ package dev
 
 import (
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/discovery"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -34,17 +35,18 @@ import (
 var _ profiles.ProfileReconciler = &developmentProfile{}
 
 type developmentProfile struct {
-	common.BaseReconciler
+	common.Reconciler
 }
 
 func (d developmentProfile) GetProfile() metadata.ProfileType {
 	return metadata.DevProfile
 }
 
-func NewProfileReconciler(client client.Client) profiles.ProfileReconciler {
+func NewProfileReconciler(client client.Client, recorder record.EventRecorder) profiles.ProfileReconciler {
 	support := &common.StateSupport{
-		C:       client,
-		Catalog: discovery.NewServiceCatalog(client),
+		C:        client,
+		Catalog:  discovery.NewServiceCatalog(client),
+		Recorder: recorder,
 	}
 
 	var ensurers *objectEnsurers
@@ -63,7 +65,7 @@ func NewProfileReconciler(client client.Client) profiles.ProfileReconciler {
 		&recoverFromFailureState{StateSupport: support})
 
 	profile := &developmentProfile{
-		BaseReconciler: common.NewBaseProfileReconciler(support, stateMachine),
+		Reconciler: common.NewReconciler(support, stateMachine),
 	}
 
 	klog.V(log.I).InfoS("Reconciling in", "profile", profile.GetProfile())

--- a/controllers/profiles/dev/profile_dev_test.go
+++ b/controllers/profiles/dev/profile_dev_test.go
@@ -55,7 +55,7 @@ func Test_OverrideStartupProbe(t *testing.T) {
 
 	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
 
-	devReconciler := NewProfileReconciler(client)
+	devReconciler := NewProfileReconciler(client, test.NewFakeRecorder())
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
@@ -82,7 +82,7 @@ func Test_recoverFromFailureNoDeployment(t *testing.T) {
 	workflow.Status.Manager().MarkFalse(api.RunningConditionType, api.DeploymentFailureReason, "")
 	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
 
-	reconciler := NewProfileReconciler(client)
+	reconciler := NewProfileReconciler(client, test.NewFakeRecorder())
 
 	// we are in failed state and have no objects
 	result, err := reconciler.Reconcile(context.TODO(), workflow)
@@ -123,7 +123,7 @@ func Test_newDevProfile(t *testing.T) {
 
 	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
 
-	devReconciler := NewProfileReconciler(client)
+	devReconciler := NewProfileReconciler(client, test.NewFakeRecorder())
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
@@ -196,7 +196,7 @@ func Test_newDevProfile(t *testing.T) {
 func Test_devProfileImageDefaultsNoPlatform(t *testing.T) {
 	workflow := test.GetBaseSonataFlowWithDevProfile(t.Name())
 	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
-	devReconciler := NewProfileReconciler(client)
+	devReconciler := NewProfileReconciler(client, test.NewFakeRecorder())
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
@@ -213,7 +213,7 @@ func Test_devProfileWithImageSnapshotOverrideWithPlatform(t *testing.T) {
 	platform := test.GetBasePlatformWithDevBaseImageInReadyPhase(workflow.Namespace)
 
 	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, platform).WithStatusSubresource(workflow, platform).Build()
-	devReconciler := NewProfileReconciler(client)
+	devReconciler := NewProfileReconciler(client, test.NewFakeRecorder())
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
@@ -230,7 +230,7 @@ func Test_devProfileWithWPlatformWithoutDevBaseImageAndWithBaseImage(t *testing.
 	platform := test.GetBasePlatformWithBaseImageInReadyPhase(workflow.Namespace)
 
 	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, platform).WithStatusSubresource(workflow, platform).Build()
-	devReconciler := NewProfileReconciler(client)
+	devReconciler := NewProfileReconciler(client, test.NewFakeRecorder())
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
@@ -247,7 +247,7 @@ func Test_devProfileWithPlatformWithoutDevBaseImageAndWithoutBaseImage(t *testin
 	platform := test.GetBasePlatformInReadyPhase(workflow.Namespace)
 
 	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, platform).WithStatusSubresource(workflow, platform).Build()
-	devReconciler := NewProfileReconciler(client)
+	devReconciler := NewProfileReconciler(client, test.NewFakeRecorder())
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
@@ -266,7 +266,7 @@ func Test_newDevProfileWithExternalConfigMaps(t *testing.T) {
 
 	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow).WithStatusSubresource(workflow).Build()
 
-	devReconciler := NewProfileReconciler(client)
+	devReconciler := NewProfileReconciler(client, test.NewFakeRecorder())
 
 	camelXmlRouteFileName := "camelroute-xml"
 	xmlRoute := `<route routeConfigurationId="xmlError">
@@ -380,7 +380,7 @@ func Test_VolumeWithCapitalizedPaths(t *testing.T) {
 
 	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(workflow, configMap).WithStatusSubresource(workflow, configMap).Build()
 
-	devReconciler := NewProfileReconciler(client)
+	devReconciler := NewProfileReconciler(client, test.NewFakeRecorder())
 
 	result, err := devReconciler.Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)

--- a/controllers/profiles/dev/states_dev.go
+++ b/controllers/profiles/dev/states_dev.go
@@ -150,7 +150,7 @@ func (f *followWorkflowDeploymentState) CanReconcile(workflow *operatorapi.Sonat
 }
 
 func (f *followWorkflowDeploymentState) Do(ctx context.Context, workflow *operatorapi.SonataFlow) (ctrl.Result, []client.Object, error) {
-	result, err := common.DeploymentHandler(f.C).SyncDeploymentStatus(ctx, workflow)
+	result, err := common.DeploymentManager(f.C).SyncDeploymentStatus(ctx, workflow)
 	if err != nil {
 		return ctrl.Result{RequeueAfter: constants.RequeueAfterFailure}, nil, err
 	}

--- a/controllers/profiles/dev/states_dev.go
+++ b/controllers/profiles/dev/states_dev.go
@@ -135,6 +135,11 @@ func (e *ensureRunningWorkflowState) Do(ctx context.Context, workflow *operatora
 	return ctrl.Result{RequeueAfter: constants.RequeueAfterIsRunning}, objs, nil
 }
 
+func (e *ensureRunningWorkflowState) PostReconcile(ctx context.Context, workflow *operatorapi.SonataFlow) error {
+	//By default, we don't want to perform anything after the reconciliation, and so we will simply return no error
+	return nil
+}
+
 type followWorkflowDeploymentState struct {
 	*common.StateSupport
 	enrichers *statusEnrichers
@@ -246,4 +251,9 @@ func (r *recoverFromFailureState) Do(ctx context.Context, workflow *operatorapi.
 		return ctrl.Result{Requeue: false}, nil, err
 	}
 	return ctrl.Result{RequeueAfter: constants.RequeueRecoverDeploymentErrorInterval}, nil, nil
+}
+
+func (r *recoverFromFailureState) PostReconcile(ctx context.Context, workflow *operatorapi.SonataFlow) error {
+	//By default, we don't want to perform anything after the reconciliation, and so we will simply return no error
+	return nil
 }

--- a/controllers/profiles/factory/factory.go
+++ b/controllers/profiles/factory/factory.go
@@ -20,6 +20,7 @@
 package factory
 
 import (
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/apache/incubator-kie-kogito-serverless-operator/api/metadata"
@@ -35,7 +36,7 @@ const (
 	opsProfile metadata.ProfileType = "prod_for_ops"
 )
 
-type reconcilerBuilder func(client client.Client) profiles.ProfileReconciler
+type reconcilerBuilder func(client client.Client, recorder record.EventRecorder) profiles.ProfileReconciler
 
 var profileBuilders = map[metadata.ProfileType]reconcilerBuilder{
 	metadata.ProdProfile: prod.NewProfileReconciler,
@@ -58,6 +59,6 @@ func profileBuilder(workflow *operatorapi.SonataFlow) reconcilerBuilder {
 }
 
 // NewReconciler creates a new ProfileReconciler based on the given workflow and context.
-func NewReconciler(client client.Client, workflow *operatorapi.SonataFlow) profiles.ProfileReconciler {
-	return profileBuilder(workflow)(client)
+func NewReconciler(client client.Client, recorder record.EventRecorder, workflow *operatorapi.SonataFlow) profiles.ProfileReconciler {
+	return profileBuilder(workflow)(client, recorder)
 }

--- a/controllers/profiles/prod/deployment_handler_test.go
+++ b/controllers/profiles/prod/deployment_handler_test.go
@@ -33,9 +33,9 @@ func Test_CheckPodTemplateChangesReflectDeployment(t *testing.T) {
 		WithStatusSubresource(workflow).
 		Build()
 	stateSupport := fakeReconcilerSupport(client)
-	handler := newDeploymentHandler(stateSupport, newObjectEnsurers(stateSupport))
+	handler := newDeploymentReconciler(stateSupport, newObjectEnsurers(stateSupport))
 
-	result, objects, err := handler.handle(context.TODO(), workflow)
+	result, objects, err := handler.reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, objects)
 	assert.True(t, result.Requeue)
@@ -44,7 +44,7 @@ func Test_CheckPodTemplateChangesReflectDeployment(t *testing.T) {
 	expectedImg := "quay.io/apache/my-new-workflow:1.0.0"
 	workflow.Spec.PodTemplate.Container.Image = expectedImg
 	utilruntime.Must(client.Update(context.TODO(), workflow))
-	result, objects, err = handler.handle(context.TODO(), workflow)
+	result, objects, err = handler.reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, objects)
 	assert.True(t, result.Requeue)

--- a/controllers/profiles/prod/profile_prod.go
+++ b/controllers/profiles/prod/profile_prod.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/discovery"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -34,7 +35,7 @@ import (
 var _ profiles.ProfileReconciler = &prodProfile{}
 
 type prodProfile struct {
-	common.BaseReconciler
+	common.Reconciler
 }
 
 const (
@@ -64,10 +65,11 @@ func newObjectEnsurers(support *common.StateSupport) *objectEnsurers {
 
 // NewProfileReconciler the default profile builder which includes a build state to run an internal build process
 // to have an immutable workflow image deployed
-func NewProfileReconciler(client client.Client) profiles.ProfileReconciler {
+func NewProfileReconciler(client client.Client, recorder record.EventRecorder) profiles.ProfileReconciler {
 	support := &common.StateSupport{
-		C:       client,
-		Catalog: discovery.NewServiceCatalog(client),
+		C:        client,
+		Catalog:  discovery.NewServiceCatalog(client),
+		Recorder: recorder,
 	}
 	// the reconciliation state machine
 	stateMachine := common.NewReconciliationStateMachine(
@@ -76,7 +78,7 @@ func NewProfileReconciler(client client.Client) profiles.ProfileReconciler {
 		&deployWithBuildWorkflowState{StateSupport: support, ensurers: newObjectEnsurers(support)},
 	)
 	reconciler := &prodProfile{
-		BaseReconciler: common.NewBaseProfileReconciler(support, stateMachine),
+		Reconciler: common.NewReconciler(support, stateMachine),
 	}
 
 	return reconciler
@@ -84,10 +86,11 @@ func NewProfileReconciler(client client.Client) profiles.ProfileReconciler {
 
 // NewProfileForOpsReconciler creates an alternative prod profile that won't require to build the workflow image in order to deploy
 // the workflow application. It assumes that the image has been built somewhere else.
-func NewProfileForOpsReconciler(client client.Client) profiles.ProfileReconciler {
+func NewProfileForOpsReconciler(client client.Client, recorder record.EventRecorder) profiles.ProfileReconciler {
 	support := &common.StateSupport{
-		C:       client,
-		Catalog: discovery.NewServiceCatalog(client),
+		C:        client,
+		Catalog:  discovery.NewServiceCatalog(client),
+		Recorder: recorder,
 	}
 	// the reconciliation state machine
 	stateMachine := common.NewReconciliationStateMachine(
@@ -95,7 +98,7 @@ func NewProfileForOpsReconciler(client client.Client) profiles.ProfileReconciler
 		&followDeployWorkflowState{StateSupport: support, ensurers: newObjectEnsurers(support)},
 	)
 	reconciler := &prodProfile{
-		BaseReconciler: common.NewBaseProfileReconciler(support, stateMachine),
+		Reconciler: common.NewReconciler(support, stateMachine),
 	}
 
 	return reconciler

--- a/controllers/profiles/prod/profile_prod_test.go
+++ b/controllers/profiles/prod/profile_prod_test.go
@@ -130,7 +130,7 @@ func Test_reconcilerProdBuildConditions(t *testing.T) {
 	assert.Equal(t, requeueWhileWaitForBuild, result.RequeueAfter)
 	assert.False(t, workflow.Status.IsBuildRunningOrUnknown())
 	assert.False(t, workflow.Status.IsReady())
-	assert.Equal(t, api.WaitingForBuildReason, workflow.Status.GetTopLevelCondition().Reason)
+	assert.Equal(t, api.WaitingForDeploymentReason, workflow.Status.GetTopLevelCondition().Reason)
 
 	// now we create the objects
 	result, err = NewProfileReconciler(client, test.NewFakeRecorder()).Reconcile(context.TODO(), workflow)

--- a/controllers/profiles/prod/profile_prod_test.go
+++ b/controllers/profiles/prod/profile_prod_test.go
@@ -24,17 +24,14 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-
-	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/profiles/common"
-
-	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
-	clientruntime "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/apache/incubator-kie-kogito-serverless-operator/api"
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/profiles/common"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/test"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	clientruntime "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func Test_Reconciler_ProdOps(t *testing.T) {
@@ -47,18 +44,18 @@ func Test_Reconciler_ProdOps(t *testing.T) {
 	client := test.NewSonataFlowClientBuilder().
 		WithRuntimeObjects(workflow).
 		WithStatusSubresource(workflow, &operatorapi.SonataFlowBuild{}).Build()
-	result, err := NewProfileForOpsReconciler(client).Reconcile(context.TODO(), workflow)
+	result, err := NewProfileForOpsReconciler(client, test.NewFakeRecorder()).Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 
 	assert.NotNil(t, result.RequeueAfter)
 	assert.True(t, workflow.Status.GetCondition(api.BuiltConditionType).IsFalse())
-	assert.Equal(t, api.BuildSkipped, workflow.Status.GetCondition(api.BuiltConditionType).Reason)
+	assert.Equal(t, api.BuildSkippedReason, workflow.Status.GetCondition(api.BuiltConditionType).Reason)
 	// We need the deployment controller to tell us that the workflow is ready
 	// Since we don't have it in a mocked env, the result must be ready == false
 	assert.False(t, workflow.Status.IsReady())
 
 	// Reconcile again to run the ddeployment handler
-	result, err = NewProfileForOpsReconciler(client).Reconcile(context.TODO(), workflow)
+	result, err = NewProfileForOpsReconciler(client, test.NewFakeRecorder()).Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 
 	// Let's check for the right creation of the workflow (one CM volume, one container with a custom image)
@@ -86,7 +83,7 @@ func Test_Reconciler_ProdCustomPod(t *testing.T) {
 	client := test.NewSonataFlowClientBuilder().
 		WithRuntimeObjects(workflow, build, platform).
 		WithStatusSubresource(workflow, build, platform).Build()
-	_, err := NewProfileReconciler(client).Reconcile(context.TODO(), workflow)
+	_, err := NewProfileReconciler(client, test.NewFakeRecorder()).Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 
 	// Let's check for the right creation of the workflow (one CM volume, one container with a custom image)
@@ -107,7 +104,7 @@ func Test_reconcilerProdBuildConditions(t *testing.T) {
 		WithRuntimeObjects(workflow, platform).
 		WithStatusSubresource(workflow, platform, &operatorapi.SonataFlowBuild{}).Build()
 
-	result, err := NewProfileReconciler(client).Reconcile(context.TODO(), workflow)
+	result, err := NewProfileReconciler(client, test.NewFakeRecorder()).Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 
 	assert.NotNil(t, result.RequeueAfter)
@@ -115,7 +112,7 @@ func Test_reconcilerProdBuildConditions(t *testing.T) {
 	assert.False(t, workflow.Status.IsReady())
 
 	// still building
-	result, err = NewProfileReconciler(client).Reconcile(context.TODO(), workflow)
+	result, err = NewProfileReconciler(client, test.NewFakeRecorder()).Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 	assert.Equal(t, requeueWhileWaitForBuild, result.RequeueAfter)
 	assert.True(t, workflow.Status.IsBuildRunningOrUnknown())
@@ -128,7 +125,7 @@ func Test_reconcilerProdBuildConditions(t *testing.T) {
 	assert.NoError(t, client.Status().Update(context.TODO(), build))
 
 	// last reconciliation cycle waiting for build
-	result, err = NewProfileReconciler(client).Reconcile(context.TODO(), workflow)
+	result, err = NewProfileReconciler(client, test.NewFakeRecorder()).Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 	assert.Equal(t, requeueWhileWaitForBuild, result.RequeueAfter)
 	assert.False(t, workflow.Status.IsBuildRunningOrUnknown())
@@ -136,7 +133,7 @@ func Test_reconcilerProdBuildConditions(t *testing.T) {
 	assert.Equal(t, api.WaitingForBuildReason, workflow.Status.GetTopLevelCondition().Reason)
 
 	// now we create the objects
-	result, err = NewProfileReconciler(client).Reconcile(context.TODO(), workflow)
+	result, err = NewProfileReconciler(client, test.NewFakeRecorder()).Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 	assert.False(t, workflow.Status.IsBuildRunningOrUnknown())
 	assert.False(t, workflow.Status.IsReady())
@@ -154,7 +151,7 @@ func Test_reconcilerProdBuildConditions(t *testing.T) {
 	err = client.Status().Update(context.TODO(), deployment)
 	assert.NoError(t, err)
 
-	result, err = NewProfileReconciler(client).Reconcile(context.TODO(), workflow)
+	result, err = NewProfileReconciler(client, test.NewFakeRecorder()).Reconcile(context.TODO(), workflow)
 	assert.NoError(t, err)
 	assert.False(t, workflow.Status.IsBuildRunningOrUnknown())
 	assert.True(t, workflow.Status.IsReady())
@@ -187,24 +184,6 @@ func Test_deployWorkflowReconciliationHandler_handleObjects(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, workflow.Status.IsReady())
 	assert.Equal(t, api.WaitingForDeploymentReason, workflow.Status.GetTopLevelCondition().Reason)
-
-	// let's mess with the deployment
-	/* TODO the state should be able to enforce: https://issues.redhat.com/browse/KOGITO-8524
-	deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = 9090
-	err = client.Update(context.TODO(), deployment)
-	assert.NoError(t, err)
-	result, objects, err = handler.Do(context.TODO(), workflow)
-	assert.True(t, result.Requeue)
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
-	assert.Len(t, objects, 2)
-	// the reconciliation state should guarantee our port
-	deployment = &appsv1.Deployment{}
-	err = client.Get(context.TODO(), clientruntime.ObjectKeyFromObject(workflow), deployment)
-	assert.NoError(t, err)
-	assert.Equal(t, int32(8080), deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
-	*/
-
 }
 
 func Test_GenerationAnnotationCheck(t *testing.T) {
@@ -248,6 +227,7 @@ func Test_GenerationAnnotationCheck(t *testing.T) {
 
 func fakeReconcilerSupport(client clientruntime.Client) *common.StateSupport {
 	return &common.StateSupport{
-		C: client,
+		C:        client,
+		Recorder: test.NewFakeRecorder(),
 	}
 }

--- a/controllers/profiles/prod/states_prod_nobuild.go
+++ b/controllers/profiles/prod/states_prod_nobuild.go
@@ -33,17 +33,22 @@ type ensureBuildSkipped struct {
 func (f *ensureBuildSkipped) CanReconcile(workflow *operatorapi.SonataFlow) bool {
 	return workflow.Status.GetCondition(api.BuiltConditionType).IsUnknown() ||
 		workflow.Status.GetCondition(api.BuiltConditionType).IsTrue() ||
-		workflow.Status.GetCondition(api.BuiltConditionType).Reason != api.BuildSkipped
+		workflow.Status.GetCondition(api.BuiltConditionType).Reason != api.BuildSkippedReason
 }
 
 func (f *ensureBuildSkipped) Do(ctx context.Context, workflow *operatorapi.SonataFlow) (ctrl.Result, []client.Object, error) {
 	// We skip the build, so let's ensure the status reflect that
-	workflow.Status.Manager().MarkFalse(api.BuiltConditionType, api.BuildSkipped, "")
+	workflow.Status.Manager().MarkFalse(api.BuiltConditionType, api.BuildSkippedReason, "")
 	if _, err := f.PerformStatusUpdate(ctx, workflow); err != nil {
 		return ctrl.Result{Requeue: false}, nil, err
 	}
 
 	return ctrl.Result{Requeue: true}, nil, nil
+}
+
+func (f *ensureBuildSkipped) PostReconcile(ctx context.Context, workflow *operatorapi.SonataFlow) error {
+	//By default, we don't want to perform anything after the reconciliation, and so we will simply return no error
+	return nil
 }
 
 type followDeployWorkflowState struct {
@@ -53,9 +58,14 @@ type followDeployWorkflowState struct {
 
 func (f *followDeployWorkflowState) CanReconcile(workflow *operatorapi.SonataFlow) bool {
 	// we always reconcile since in this flow we don't mind building anything, just reconcile the deployment state
-	return workflow.Status.GetCondition(api.BuiltConditionType).Reason == api.BuildSkipped
+	return workflow.Status.GetCondition(api.BuiltConditionType).Reason == api.BuildSkippedReason
 }
 
 func (f *followDeployWorkflowState) Do(ctx context.Context, workflow *operatorapi.SonataFlow) (ctrl.Result, []client.Object, error) {
 	return newDeploymentHandler(f.StateSupport, f.ensurers).handle(ctx, workflow)
+}
+
+func (f *followDeployWorkflowState) PostReconcile(ctx context.Context, workflow *operatorapi.SonataFlow) error {
+	//By default, we don't want to perform anything after the reconciliation, and so we will simply return no error
+	return nil
 }

--- a/controllers/profiles/prod/states_prod_nobuild.go
+++ b/controllers/profiles/prod/states_prod_nobuild.go
@@ -62,7 +62,7 @@ func (f *followDeployWorkflowState) CanReconcile(workflow *operatorapi.SonataFlo
 }
 
 func (f *followDeployWorkflowState) Do(ctx context.Context, workflow *operatorapi.SonataFlow) (ctrl.Result, []client.Object, error) {
-	return newDeploymentHandler(f.StateSupport, f.ensurers).handle(ctx, workflow)
+	return newDeploymentReconciler(f.StateSupport, f.ensurers).reconcile(ctx, workflow)
 }
 
 func (f *followDeployWorkflowState) PostReconcile(ctx context.Context, workflow *operatorapi.SonataFlow) error {

--- a/controllers/sonataflow_controller.go
+++ b/controllers/sonataflow_controller.go
@@ -95,7 +95,7 @@ func (r *SonataFlowReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return reconcile.Result{}, nil
 	}
 
-	return profiles.NewReconciler(r.Client, workflow).Reconcile(ctx, workflow)
+	return profiles.NewReconciler(r.Client, r.Recorder, workflow).Reconcile(ctx, workflow)
 }
 
 func platformEnqueueRequestsFromMapFunc(c client.Client, p *operatorapi.SonataFlowPlatform) []reconcile.Request {

--- a/controllers/sonataflow_controller.go
+++ b/controllers/sonataflow_controller.go
@@ -135,7 +135,6 @@ func buildEnqueueRequestsFromMapFunc(c client.Client, b *operatorapi.SonataFlowB
 	var requests []reconcile.Request
 
 	if b.Status.BuildPhase == operatorapi.BuildPhaseSucceeded {
-
 		// Fetch the Workflow instance
 		workflow := &operatorapi.SonataFlow{}
 		namespacedName := types.NamespacedName{

--- a/controllers/sonataflow_controller_test.go
+++ b/controllers/sonataflow_controller_test.go
@@ -49,7 +49,7 @@ func TestSonataFlowController(t *testing.T) {
 		// Create a fake client to mock API calls.
 		cl := test.NewSonataFlowClientBuilder().WithRuntimeObjects(objs...).WithStatusSubresource(ksw, ksp).Build()
 		// Create a SonataFlowReconciler object with the scheme and fake client.
-		r := &SonataFlowReconciler{Client: cl, Scheme: cl.Scheme()}
+		r := &SonataFlowReconciler{Client: cl, Scheme: cl.Scheme(), Recorder: test.NewFakeRecorder()}
 
 		// Mock request to simulate Reconcile() being called on an event for a
 		// watched resource .

--- a/controllers/workflows/workflows.go
+++ b/controllers/workflows/workflows.go
@@ -28,7 +28,7 @@ var _ WorkflowManager = &workflowManager{}
 // WorkflowManager offers a management interface for operations with SonataFlows instances outside the controller's package.
 // Meant to be used by other packages that don't have access to a SonataFlow instance coming from a reconciliation cycle.
 type WorkflowManager interface {
-	SetBuiltStatusToWaitForBuild(message string) error
+	SetBuiltStatusToRunning(message string) error
 	GetWorkflow() *v1alpha08.SonataFlow
 }
 
@@ -42,8 +42,8 @@ func (w *workflowManager) GetWorkflow() *v1alpha08.SonataFlow {
 	return w.workflow
 }
 
-func (w *workflowManager) SetBuiltStatusToWaitForBuild(message string) error {
-	w.workflow.Status.Manager().MarkFalse(api.BuiltConditionType, api.WaitingForBuildReason, message)
+func (w *workflowManager) SetBuiltStatusToRunning(message string) error {
+	w.workflow.Status.Manager().MarkFalse(api.BuiltConditionType, api.BuildIsRunningReason, message)
 	return w.client.Status().Update(w.ctx, w.workflow)
 }
 

--- a/controllers/workflows/workflows.go
+++ b/controllers/workflows/workflows.go
@@ -1,0 +1,60 @@
+// Copyright 2023 Apache Software Foundation (ASF)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflows
+
+import (
+	"context"
+
+	"github.com/apache/incubator-kie-kogito-serverless-operator/api"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ WorkflowManager = &workflowManager{}
+
+// WorkflowManager offers a management interface for operations with SonataFlows instances outside the controller's package.
+// Meant to be used by other packages that don't have access to a SonataFlow instance coming from a reconciliation cycle.
+type WorkflowManager interface {
+	SetBuiltStatusToWaitForBuild(message string) error
+	GetWorkflow() *v1alpha08.SonataFlow
+}
+
+type workflowManager struct {
+	workflow *v1alpha08.SonataFlow
+	client   client.Client
+	ctx      context.Context
+}
+
+func (w *workflowManager) GetWorkflow() *v1alpha08.SonataFlow {
+	return w.workflow
+}
+
+func (w *workflowManager) SetBuiltStatusToWaitForBuild(message string) error {
+	w.workflow.Status.Manager().MarkFalse(api.BuiltConditionType, api.WaitingForBuildReason, message)
+	return w.client.Status().Update(w.ctx, w.workflow)
+}
+
+func NewManager(client client.Client, ctx context.Context, ns, name string) (WorkflowManager, error) {
+	workflow := &v1alpha08.SonataFlow{}
+	if err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, workflow); err != nil {
+		return nil, err
+	}
+	return &workflowManager{
+		workflow: workflow,
+		client:   client,
+		ctx:      ctx,
+	}, nil
+}

--- a/test/kubernetes_cli.go
+++ b/test/kubernetes_cli.go
@@ -32,11 +32,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 )
+
+func NewFakeRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(10)
+}
 
 // NewSonataFlowClientBuilder creates a new fake.ClientBuilder with the right scheme references
 func NewSonataFlowClientBuilder() *fake.ClientBuilder {

--- a/test/kubernetes_cli.go
+++ b/test/kubernetes_cli.go
@@ -83,6 +83,13 @@ func MustGetWorkflow(t *testing.T, client ctrl.WithWatch, name types.NamespacedN
 	return mustGet(t, client, workflow, workflow).(*operatorapi.SonataFlow)
 }
 
+func MustGetBuild(t *testing.T, client ctrl.WithWatch, name types.NamespacedName) *operatorapi.SonataFlowBuild {
+	build := &operatorapi.SonataFlowBuild{}
+	err := client.Get(context.TODO(), name, build)
+	assert.NoError(t, err)
+	return build
+}
+
 func mustGet(t *testing.T, client ctrl.WithWatch, workflow *operatorapi.SonataFlow, obj ctrl.Object) ctrl.Object {
 	err := client.Get(context.TODO(), ctrl.ObjectKeyFromObject(workflow), obj)
 	assert.NoError(t, err)

--- a/test/mock_service.go
+++ b/test/mock_service.go
@@ -22,8 +22,6 @@ package test
 import (
 	"context"
 
-	"k8s.io/klog/v2"
-
 	oappsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	consolev1 "github.com/openshift/api/console/v1"
@@ -35,10 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientv1 "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	apiv08 "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
-	"github.com/apache/incubator-kie-kogito-serverless-operator/log"
 )
 
 type MockPlatformService struct {
@@ -54,10 +48,6 @@ type MockPlatformService struct {
 	GetCachedFunc   func(ctx context.Context, key clientv1.ObjectKey, obj clientv1.Object) error
 	GetSchemeFunc   func() *runtime.Scheme
 	StatusFunc      func() clientv1.StatusWriter
-}
-
-func MockService() *MockPlatformService {
-	return MockServiceWithExtraScheme()
 }
 
 var knownTypes = map[schema.GroupVersion][]runtime.Object{
@@ -104,54 +94,6 @@ var knownTypes = map[schema.GroupVersion][]runtime.Object{
 		&consolev1.ConsoleYAMLSample{},
 		&consolev1.ConsoleYAMLSampleList{},
 	},
-}
-
-func MockServiceWithExtraScheme(objs ...runtime.Object) *MockPlatformService {
-	registerObjs := []runtime.Object{&apiv08.SonataFlow{}, &apiv08.SonataFlowList{}}
-	registerObjs = append(registerObjs, objs...)
-	apiv08.SchemeBuilder.Register(registerObjs...)
-	scheme, _ := apiv08.SchemeBuilder.Build()
-	for gv, types := range knownTypes {
-		for _, t := range types {
-			scheme.AddKnownTypes(gv, t)
-		}
-	}
-	client := fake.NewFakeClientWithScheme(scheme)
-	klog.V(log.D).InfoS("Fake client created", "client", client)
-	return &MockPlatformService{
-		Client: client,
-		scheme: scheme,
-		CreateFunc: func(ctx context.Context, obj clientv1.Object, opts ...clientv1.CreateOption) error {
-			return client.Create(ctx, obj, opts...)
-		},
-		DeleteFunc: func(ctx context.Context, obj clientv1.Object, opts ...clientv1.DeleteOption) error {
-			return client.Delete(ctx, obj, opts...)
-		},
-		GetFunc: func(ctx context.Context, key clientv1.ObjectKey, obj clientv1.Object) error {
-			return client.Get(ctx, key, obj)
-		},
-		ListFunc: func(ctx context.Context, list clientv1.ObjectList, opts ...clientv1.ListOption) error {
-			return client.List(ctx, list, opts...)
-		},
-		UpdateFunc: func(ctx context.Context, obj clientv1.Object, opts ...clientv1.UpdateOption) error {
-			return client.Update(ctx, obj, opts...)
-		},
-		PatchFunc: func(ctx context.Context, obj clientv1.Object, patch clientv1.Patch, opts ...clientv1.PatchOption) error {
-			return client.Patch(ctx, obj, patch, opts...)
-		},
-		DeleteAllOfFunc: func(ctx context.Context, obj clientv1.Object, opts ...clientv1.DeleteAllOfOption) error {
-			return client.DeleteAllOf(ctx, obj, opts...)
-		},
-		GetCachedFunc: func(ctx context.Context, key clientv1.ObjectKey, obj clientv1.Object) error {
-			return client.Get(ctx, key, obj)
-		},
-		GetSchemeFunc: func() *runtime.Scheme {
-			return scheme
-		},
-		StatusFunc: func() clientv1.StatusWriter {
-			return client.Status()
-		},
-	}
 }
 
 func (service *MockPlatformService) Create(ctx context.Context, obj clientv1.Object, opts ...clientv1.CreateOption) error {

--- a/utils/kubernetes/annotations.go
+++ b/utils/kubernetes/annotations.go
@@ -21,6 +21,7 @@ package kubernetes
 
 import (
 	"context"
+	"strconv"
 
 	"k8s.io/klog/v2"
 
@@ -44,4 +45,26 @@ func getWorkflow(namespace string, name string, c client.Client, ctx context.Con
 func GetLastGeneration(namespace string, name string, c client.Client, ctx context.Context) int64 {
 	workflow := getWorkflow(namespace, name, c, ctx)
 	return workflow.Generation
+}
+
+// GetAnnotationAsBool returns the boolean value from the given annotation.
+// If the annotation is not present or is there an error in the ParseBool conversion, returns false.
+func GetAnnotationAsBool(object client.Object, key string) bool {
+	if object.GetAnnotations() != nil {
+		b, err := strconv.ParseBool(object.GetAnnotations()[key])
+		if err != nil {
+			return false
+		}
+		return b
+	}
+	return false
+}
+
+// SetAnnotation Safely set the annotation to the object
+func SetAnnotation(object client.Object, key, value string) {
+	if object.GetAnnotations() != nil {
+		object.GetAnnotations()[key] = value
+	} else {
+		object.SetAnnotations(map[string]string{key: value})
+	}
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-8792

In this PR:

- We add the ability to register events for build phase changes within the workflow object.
- Users can now rebuild a failed build (or for any other reasons they need) by setting the annotation `sonataflow.org/restartBuild: true` to a given build instance.
- There's a small refactoring where we remove the `PostReconcile` method from the `StateSupport` struct since it does not belong there. The tradeoff is to add the noop implementation to other states. We could infer the annotation in the reconciliation state loop by verifying if it implements the post-reconcile hook and then calls it or we could create a hook and only call if it's not null. However, I decided to go to this path that looks cleaner and makes the interface easier to understand.

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>