### PR TITLE
Fix #359 - Change pullpolicy conditionally based on image tag

### DIFF
--- a/container-builder/cleaner/docker_integration_test.go
+++ b/container-builder/cleaner/docker_integration_test.go
@@ -50,6 +50,7 @@ func (suite *DockerTestSuite) TestImagesOperationsOnDockerRegistryForTest() {
 	repos, err := registryContainer.GetRepositories()
 	initialSize := len(repos)
 	assert.Nil(suite.T(), err)
+
 	pullErr := suite.Docker.PullImage(testImg + ":" + latestTag)
 	if pullErr != nil {
 		klog.V(log.E).ErrorS(pullErr, "Pull Error")

--- a/container-builder/cleaner/docker_integration_test.go
+++ b/container-builder/cleaner/docker_integration_test.go
@@ -50,7 +50,6 @@ func (suite *DockerTestSuite) TestImagesOperationsOnDockerRegistryForTest() {
 	repos, err := registryContainer.GetRepositories()
 	initialSize := len(repos)
 	assert.Nil(suite.T(), err)
-
 	pullErr := suite.Docker.PullImage(testImg + ":" + latestTag)
 	if pullErr != nil {
 		klog.V(log.E).ErrorS(pullErr, "Pull Error")

--- a/controllers/platform/k8s.go
+++ b/controllers/platform/k8s.go
@@ -104,12 +104,14 @@ func createDeployment(ctx context.Context, client client.Client, platform *opera
 	}
 	liveProbe := readyProbe.DeepCopy()
 	liveProbe.ProbeHandler.HTTPGet.Path = common.QuarkusHealthPathLive
+	imageTag := psh.GetServiceImageName(constants.PersistenceTypeEphemeral)
 	dataDeployContainer := &corev1.Container{
-		Image:          psh.GetServiceImageName(constants.PersistenceTypeEphemeral),
-		Env:            psh.GetEnvironmentVariables(),
-		Resources:      psh.GetPodResourceRequirements(),
-		ReadinessProbe: readyProbe,
-		LivenessProbe:  liveProbe,
+		Image:           imageTag,
+		ImagePullPolicy: kubeutil.GetImagePullPolicy(imageTag),
+		Env:             psh.GetEnvironmentVariables(),
+		Resources:       psh.GetPodResourceRequirements(),
+		ReadinessProbe:  readyProbe,
+		LivenessProbe:   liveProbe,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          utils.HttpScheme,
@@ -117,7 +119,6 @@ func createDeployment(ctx context.Context, client client.Client, platform *opera
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		ImagePullPolicy: corev1.PullAlways,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "application-config",

--- a/controllers/profiles/common/mutate_visitors.go
+++ b/controllers/profiles/common/mutate_visitors.go
@@ -50,6 +50,7 @@ func ImageDeploymentMutateVisitor(workflow *operatorapi.SonataFlow, image string
 			deployment := object.(*appsv1.Deployment)
 			_, idx := kubeutil.GetContainerByName(operatorapi.DefaultContainerName, &deployment.Spec.Template.Spec)
 			deployment.Spec.Template.Spec.Containers[idx].Image = image
+			deployment.Spec.Template.Spec.Containers[idx].ImagePullPolicy = kubeutil.GetImagePullPolicy(image)
 			return nil
 		}
 	}

--- a/controllers/profiles/common/object_creators.go
+++ b/controllers/profiles/common/object_creators.go
@@ -147,7 +147,6 @@ func defaultContainer(workflow *operatorapi.SonataFlow) (*corev1.Container, erro
 			FailureThreshold:    healthStartedFailureThreshold,
 			PeriodSeconds:       healthStartedPeriodSeconds,
 		},
-		ImagePullPolicy: corev1.PullAlways,
 		SecurityContext: kubeutil.SecurityDefaults(),
 	}
 	// Merge with flowContainer

--- a/utils/kubernetes/image.go
+++ b/utils/kubernetes/image.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Apache Software Foundation (ASF)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetImagePullPolicy gets the default corev1.PullPolicy depending on the image tag specified.
+// It follows the conventions of docker client and OpenShift. If no tag specified, it assumes latest.
+// Returns PullAlways if latest tag, empty otherwise to let the cluster figure it out.
+func GetImagePullPolicy(imageTag string) corev1.PullPolicy {
+	if len(imageTag) == 0 {
+		return ""
+	}
+	idx := strings.LastIndex(imageTag, ":")
+	if idx < 0 {
+		return corev1.PullAlways
+	}
+	tag := imageTag[idx+1:]
+	if tag == "latest" {
+		return corev1.PullAlways
+	}
+	return ""
+}

--- a/utils/kubernetes/image_test.go
+++ b/utils/kubernetes/image_test.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Apache Software Foundation (ASF)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestGetImagePullPolicy(t *testing.T) {
+	type args struct {
+		imageTag string
+	}
+	tests := []struct {
+		name string
+		args args
+		want v1.PullPolicy
+	}{
+		{"Short name with latest", args{"ubi9-micro:latest"}, v1.PullAlways},
+		{"Long name with latest", args{"gcr.io/knative-releases/knative.dev/eventing/cmd/event_display:latest"}, v1.PullAlways},
+		{"No tag specified", args{"ubi9-micro"}, v1.PullAlways},
+		{"Short name with tag", args{"ubi9-micro:9.3.1-2"}, ""},
+		{"Long name with tag", args{"gcr.io/knative-releases/knative.dev/eventing/cmd/event_display:1.2"}, ""},
+		{"Empty tag", args{""}, ""},
+		{"Messy tag", args{":"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, GetImagePullPolicy(tt.args.imageTag), "GetImagePullPolicy(%v)", tt.args.imageTag)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
In this PR, we add the ability to pick the `PullPolicy` in the containers we deploy based on the image tag to follow Kubernetes/OpenShift conventions.

**Motivation for the change:**
Fix #359 

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>