### PR TITLE
Fixes checks workflow by running apt-get update 

### DIFF
--- a/.github/workflows/check-container-builder.yml
+++ b/.github/workflows/check-container-builder.yml
@@ -58,7 +58,8 @@ jobs:
     steps:
       - name: Install packages
         run: |
-          sudo apt-get -y install \
+          sudo apt-get update && \
+          sudo apt-get -y install --no-install-recommends \
           libgpgme-dev \
           libbtrfs-dev \
           libdevmapper-dev

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,7 +87,8 @@ jobs:
       # we should be able to remove this after https://issues.redhat.com/browse/KOGITO-9106
       - name: Install packages
         run: |
-          sudo apt-get -y install \
+          sudo apt-get update && \
+          sudo apt-get -y install --no-install-recommends \
           btrfs-progs \
           libgpgme-dev \
           libbtrfs-dev \


### PR DESCRIPTION
Fixes checks workflow by running `apt-get update` before `apt-get install` and also adds flag `--no-install-recommends` to standardize with the other workflows since they share the same package installation call.

`--no-install-recommends` ensures that apt-get will only install the main dependencies, that's packages in the Depends field.

@ricardozanini @domhanak PTAL. This fixes the build workflow.