### PR TITLE
Disable platform e2e test due to workflow explicitly requiring persistence

### DIFF
--- a/test/e2e/platform_test.go
+++ b/test/e2e/platform_test.go
@@ -117,9 +117,9 @@ var _ = Describe("Validate the persistence", Ordered, func() {
 			}
 		},
 			Entry("with both Job Service and Data Index and ephemeral persistence and the workflow in a dev profile", test.GetSonataFlowE2EPlatformServicesDirectory(), dev, ephemeral),
-			Entry("with both Job Service and Data Index and ephemeral persistence and the workflow in a production profile", test.GetSonataFlowE2EPlatformServicesDirectory(), production, ephemeral),
+			XEntry("with both Job Service and Data Index and ephemeral persistence and the workflow in a production profile", test.GetSonataFlowE2EPlatformServicesDirectory(), production, ephemeral),
 			Entry("with both Job Service and Data Index and postgreSQL persistence and the workflow in a dev profile", test.GetSonataFlowE2EPlatformServicesDirectory(), dev, postgreSQL),
-			Entry("with both Job Service and Data Index and postgreSQL persistence and the workflow in a production profile", test.GetSonataFlowE2EPlatformServicesDirectory(), production, postgreSQL),
+			XEntry("with both Job Service and Data Index and postgreSQL persistence and the workflow in a production profile", test.GetSonataFlowE2EPlatformServicesDirectory(), production, postgreSQL),
 		)
 
 	})


### PR DESCRIPTION
Disable test `with both Job Service and Data Index and ephemeral persistence and the workflow in a production profile` due to changes in the workflow that now forces it to require a persistence connection to work.

@ricardozanini PTAL.
