### PR TITLE
Fixes kind create cluster script that contained a hardcoded IP

### DIFF
--- a/hack/ci/create-kind-cluster-with-registry.sh
+++ b/hack/ci/create-kind-cluster-with-registry.sh
@@ -64,9 +64,11 @@ fi
 #
 # We want a consistent name that works from both ends, so we tell containerd to
 # alias localhost:${reg_port} to the registry container when pulling images
-REGISTRY_DIR="/etc/containerd/certs.d/172.18.0.3:5000"
-# retrieve IP address of the container connected to the cluster network
+
+# Retrieve IP address of the container connected to the cluster network
 IP_ADDRESS=$(docker inspect --format='{{(index (index .NetworkSettings.Networks "kind") ).IPAddress}}' ${reg_name})
+
+REGISTRY_DIR="/etc/containerd/certs.d/${IP_ADDRESS}:5000"
 for node in $(kind get nodes); do
   docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
   cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"


### PR DESCRIPTION
Removes a hardcoded IP that defined the directory inside `/etc/containerd` for the registry configuration. When the IPs mismatched it caused a failure to pull or push images from the insecure registry via kaniko builder with Kind.   The correct approach is to use the IP from the docker network configuration for the registry container for both the directory name and the configuration contained within.

@wmedvede @ricardozanini PTAL.