### PR TITLE
Add property to ensure Data Index readiness

### DIFF
--- a/controllers/platform/services/properties.go
+++ b/controllers/platform/services/properties.go
@@ -165,6 +165,7 @@ func GenerateDataIndexWorkflowProperties(workflow *operatorapi.SonataFlow, platf
 	di := NewDataIndexHandler(platform)
 	if workflow != nil && !profiles.IsDevProfile(workflow) && di.IsServiceEnabled() {
 		props.Set(constants.KogitoProcessDefinitionsEventsEnabled, "true")
+		props.Set(constants.KogitoProcessDefinitionsErrorsPropagated, "true")
 		props.Set(constants.KogitoProcessInstancesEventsEnabled, "true")
 		props.Set(constants.KogitoDataIndexHealthCheckEnabled, "true")
 		di := NewDataIndexHandler(platform)

--- a/controllers/profiles/common/constants/platform_services.go
+++ b/controllers/profiles/common/constants/platform_services.go
@@ -34,14 +34,15 @@ const (
 	JobServiceDataSourceReactiveURL  = "quarkus.datasource.reactive.url"
 	JobServiceJobEventsPath          = "/v2/jobs/events"
 
-	KogitoProcessEventsProtocol           = "http"
-	KogitoProcessInstancesEventsURL       = "mp.messaging.outgoing.kogito-processinstances-events.url"
-	KogitoProcessInstancesEventsEnabled   = "kogito.events.processinstances.enabled"
-	KogitoProcessInstancesEventsPath      = "/processes"
-	KogitoProcessDefinitionsEventsURL     = "mp.messaging.outgoing.kogito-processdefinitions-events.url"
-	KogitoProcessDefinitionsEventsEnabled = "kogito.events.processdefinitions.enabled"
-	KogitoProcessDefinitionsEventsPath    = "/definitions"
-	KogitoUserTasksEventsEnabled          = "kogito.events.usertasks.enabled"
+	KogitoProcessEventsProtocol              = "http"
+	KogitoProcessInstancesEventsURL          = "mp.messaging.outgoing.kogito-processinstances-events.url"
+	KogitoProcessInstancesEventsEnabled      = "kogito.events.processinstances.enabled"
+	KogitoProcessInstancesEventsPath         = "/processes"
+	KogitoProcessDefinitionsEventsURL        = "mp.messaging.outgoing.kogito-processdefinitions-events.url"
+	KogitoProcessDefinitionsEventsEnabled    = "kogito.events.processdefinitions.enabled"
+	KogitoProcessDefinitionsErrorsPropagated = "kogito.events.processdefinitions.errors.propagate"
+	KogitoProcessDefinitionsEventsPath       = "/definitions"
+	KogitoUserTasksEventsEnabled             = "kogito.events.usertasks.enabled"
 	// KogitoDataIndexHealthCheckEnabled configures if a workflow must check for the data index availability as part
 	// of its start health check.
 	KogitoDataIndexHealthCheckEnabled = "kogito.data-index.health-enabled"


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
By adding a property `kogito.events.processdefinitions.errors.propagate` to the workflow's managed properties, the workflow will be restarted if failed to communicate with the Data Index.


**Motivation for the change:**
Verifying the workflow isn't reported as ready before reaching out to the Data Index and successfully publishing its process definition.

**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>