### PR TITLE
KIE Tools #2160 - Fix resources generation prefix order

### DIFF
--- a/workflowproj/io.go
+++ b/workflowproj/io.go
@@ -42,11 +42,11 @@ func ensurePath(path string) error {
 	return nil
 }
 
-func saveAsKubernetesManifest(object client.Object, savePath, prefix string) error {
+func saveAsKubernetesManifest(object client.Object, savePath string, prefix int) error {
 	if reflect.ValueOf(object).IsNil() {
 		return nil
 	}
-	filename := strings.ToLower(fmt.Sprintf("%s%s_%s%s",
+	filename := strings.ToLower(fmt.Sprintf("%02d-%s_%s%s",
 		prefix,
 		object.GetObjectKind().GroupVersionKind().Kind,
 		object.GetName(),

--- a/workflowproj/workflowproj.go
+++ b/workflowproj/workflowproj.go
@@ -153,18 +153,21 @@ func (w *workflowProjectHandler) SaveAsKubernetesManifests(path string) error {
 	if err := w.parseRawProject(); err != nil {
 		return err
 	}
-	fileCount := 1
-	if err := saveAsKubernetesManifest(w.project.Workflow, path, fmt.Sprintf("%02d-", 1)); err != nil {
-		return err
+	fileCount := 0
+	if w.project.Properties != nil {
+		fileCount++
+		if err := saveAsKubernetesManifest(w.project.Properties, path, fileCount); err != nil {
+			return err
+		}
 	}
-	for i, r := range w.project.Resources {
-		fileCount = i + 1
-		if err := saveAsKubernetesManifest(r, path, fmt.Sprintf("%02d-", fileCount)); err != nil {
+	for _, r := range w.project.Resources {
+		fileCount++
+		if err := saveAsKubernetesManifest(r, path, fileCount); err != nil {
 			return err
 		}
 	}
 	fileCount++
-	if err := saveAsKubernetesManifest(w.project.Properties, path, fmt.Sprintf("%02d-", fileCount)); err != nil {
+	if err := saveAsKubernetesManifest(w.project.Workflow, path, fileCount); err != nil {
 		return err
 	}
 	return nil

--- a/workflowproj/workflowproj_test.go
+++ b/workflowproj/workflowproj_test.go
@@ -140,8 +140,14 @@ func Test_Handler_WorklflowServiceAndPropsAndSpec_SaveAs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, files, 4)
 
-	for _, f := range files {
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name() < files[j].Name()
+	})
+
+	for fileCount, f := range files {
 		if strings.HasSuffix(f.Name(), yamlFileExt) {
+			prefix := fmt.Sprintf("%02d-", fileCount+1)
+			assert.True(t, strings.HasPrefix(f.Name(), prefix))
 			contents, err := os.ReadFile(path.Join(tmpPath, f.Name()))
 			assert.NoError(t, err)
 			decode := scheme.Codecs.UniversalDeserializer().Decode
@@ -170,6 +176,9 @@ func Test_Handler_WorkflowService_SaveAs(t *testing.T) {
 
 		for _, f := range files {
 			if strings.HasSuffix(f.Name(), yamlFileExt) {
+				// we have only one file produced in these test cases
+				prefix := fmt.Sprintf("%02d-", 1)
+				assert.True(t, strings.HasPrefix(f.Name(), prefix))
 				contents, err := os.ReadFile(path.Join(tmpPath, f.Name()))
 				assert.NoError(t, err)
 				decode := scheme.Codecs.UniversalDeserializer().Decode


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
Fixes https://github.com/apache/incubator-kie-tools/issues/2160

**Motivation for the change:**
We were mistakenly generating the CRs in an order that could spam two pods when deploying from `kn workflow cli`

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>