### PR TITLE
kie-kogito-serverless-operator-445: Add custom configuration to the DI and JS for operator managed deployments

### DIFF
--- a/controllers/platform/services/services.go
+++ b/controllers/platform/services/services.go
@@ -500,7 +500,7 @@ func mergeContainerPreservingEnvVars(dest *corev1.Container, source *corev1.Cont
 	}
 	dest.Env = currentEnv
 	for _, envVar := range source.Env {
-		kubernetes.AddIfNotPresent(dest, envVar)
+		kubernetes.AddEnvIfNotPresent(dest, envVar)
 	}
 	return nil
 }

--- a/controllers/platform/services/services.go
+++ b/controllers/platform/services/services.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/cfg"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -238,9 +239,7 @@ func (d DataIndexHandler) ConfigurePersistence(containerSpec *corev1.Container) 
 }
 
 func (d DataIndexHandler) MergeContainerSpec(containerSpec *corev1.Container) (*corev1.Container, error) {
-	c := containerSpec.DeepCopy()
-	err := mergo.Merge(c, d.platform.Spec.Services.DataIndex.PodTemplate.Container.ToContainer(), mergo.WithOverride)
-	return c, err
+	return mergeContainerSpec(containerSpec, &d.platform.Spec.Services.DataIndex.PodTemplate.Container)
 }
 
 func (d DataIndexHandler) GetReplicaCount() int32 {
@@ -387,9 +386,7 @@ func (j JobServiceHandler) GetReplicaCount() int32 {
 }
 
 func (j JobServiceHandler) MergeContainerSpec(containerSpec *corev1.Container) (*corev1.Container, error) {
-	c := containerSpec.DeepCopy()
-	err := mergo.Merge(c, j.platform.Spec.Services.JobService.PodTemplate.Container.ToContainer(), mergo.WithOverride)
-	return c, err
+	return mergeContainerSpec(containerSpec, &j.platform.Spec.Services.JobService.PodTemplate.Container)
 }
 
 // hasPostgreSQLConfigured returns true when either the SonataFlow Platform PostgreSQL CR's structure or the one in the Job service specification is not nil
@@ -481,4 +478,29 @@ func GenerateServiceURL(protocol string, namespace string, name string) string {
 		serviceUrl = fmt.Sprintf("%s://%s", protocol, name)
 	}
 	return serviceUrl
+}
+
+// mergeContainerSpec Produces the merging between the operatorapi.ContainerSpec provided in a SonataFlowPlatform
+// service, for example, platform.services.jobsService.podTemplate.container, and the destination container for the
+// corresponding service deployment. This method consider specific processing like not overriding environment vars
+// already configured by the operator in the destination container.
+func mergeContainerSpec(dest *corev1.Container, sourceSpec *operatorapi.ContainerSpec) (*corev1.Container, error) {
+	result := dest.DeepCopy()
+	source := sourceSpec.ToContainer()
+	err := mergeContainerPreservingEnvVars(result, &source)
+	return result, err
+}
+
+// mergeContainerSpecPreservingEnvVars Merges the source container into the dest container by giving priority to the
+// env variables already configured in the dest container when both containers have the same variable name.
+func mergeContainerPreservingEnvVars(dest *corev1.Container, source *corev1.Container) error {
+	currentEnv := dest.Env
+	if err := mergo.Merge(dest, source, mergo.WithOverride); err != nil {
+		return err
+	}
+	dest.Env = currentEnv
+	for _, envVar := range source.Env {
+		kubernetes.AddIfNotPresent(dest, envVar)
+	}
+	return nil
 }

--- a/controllers/platform/services/services_test.go
+++ b/controllers/platform/services/services_test.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Apache Software Foundation (ASF)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"testing"
+
+	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMergeContainerSpec(t *testing.T) {
+	container := &corev1.Container{
+		Env: []corev1.EnvVar{{Name: "var1", Value: "value1"}, {Name: "var2", Value: "value2"}},
+	}
+	containerSpec := &operatorapi.ContainerSpec{
+		Env: []corev1.EnvVar{{Name: "var1", Value: "value1Changed"}, {Name: "var3", Value: "value3"}},
+	}
+	result, err := mergeContainerSpec(container, containerSpec)
+	assert.Nil(t, err)
+	assert.Len(t, result.Env, 3)
+	assert.Equal(t, result.Env[0], corev1.EnvVar{Name: "var1", Value: "value1"})
+	assert.Equal(t, result.Env[1], corev1.EnvVar{Name: "var2", Value: "value2"})
+	assert.Equal(t, result.Env[2], corev1.EnvVar{Name: "var3", Value: "value3"})
+}
+
+func TestMergeContainerPreservingEnvVars(t *testing.T) {
+	container1 := &corev1.Container{
+		Env: []corev1.EnvVar{{Name: "var1", Value: "value1"}, {Name: "var2", Value: "value2"}},
+	}
+	container2 := &corev1.Container{
+		Env: []corev1.EnvVar{{Name: "var1", Value: "value1Changed"}, {Name: "var3", Value: "value3"}},
+	}
+	err := mergeContainerPreservingEnvVars(container1, container2)
+	assert.Nil(t, err)
+	assert.Len(t, container1.Env, 3)
+	assert.Equal(t, container1.Env[0], corev1.EnvVar{Name: "var1", Value: "value1"})
+	assert.Equal(t, container1.Env[1], corev1.EnvVar{Name: "var2", Value: "value2"})
+	assert.Equal(t, container1.Env[2], corev1.EnvVar{Name: "var3", Value: "value3"})
+}

--- a/test/testdata/platform/services/preview/postgreSQL/02-sonataflow_platform.yaml
+++ b/test/testdata/platform/services/preview/postgreSQL/02-sonataflow_platform.yaml
@@ -37,6 +37,13 @@ spec:
             image: registry.access.redhat.com/ubi9/ubi-micro:latest
             imagePullPolicy: IfNotPresent
             command: [ 'sh', '-c', 'until (echo 1 > /dev/tcp/postgres.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/5432) >/dev/null 2>&1; do echo "Waiting for postgres server"; sleep 3; done;' ]
+        container:
+          env:
+            - name: MY_CUSTOM_VARIABLE
+              value: "OKAY"
+            - name: QUARKUS_DATASOURCE_PASSWORD
+#             This value should not be used since it's already set by the operator. If used, the test will fail.
+              value: "SHOULD_NOT_BE_USED"
     jobService:
       enabled: true
       persistence:
@@ -52,3 +59,10 @@ spec:
             image: registry.access.redhat.com/ubi9/ubi-micro:latest
             imagePullPolicy: IfNotPresent
             command: [ 'sh', '-c', 'until (echo 1 > /dev/tcp/postgres.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/5432) >/dev/null 2>&1; do echo "Waiting for postgres server"; sleep 3; done;' ]
+        container:
+          env:
+            - name: MY_CUSTOM_VARIABLE
+              value: "OKAY"
+            - name: QUARKUS_DATASOURCE_PASSWORD
+#             This value should not be used since it's already set by the operator. If used, the test will fail.
+              value: "SHOULD_NOT_BE_USED"

--- a/utils/kubernetes/env.go
+++ b/utils/kubernetes/env.go
@@ -36,3 +36,15 @@ func CreateOrReplaceEnv(container *v1.Container, name, value string) {
 		})
 	}
 }
+
+// AddIfNotPresent Adds and env variable to a container if not already present. Returns true if the variable didn't exist
+// and was added, false in any other case.
+func AddIfNotPresent(container *v1.Container, envVar v1.EnvVar) bool {
+	for i := range container.Env {
+		if container.Env[i].Name == envVar.Name {
+			return false
+		}
+	}
+	container.Env = append(container.Env, envVar)
+	return true
+}

--- a/utils/kubernetes/env.go
+++ b/utils/kubernetes/env.go
@@ -37,9 +37,9 @@ func CreateOrReplaceEnv(container *v1.Container, name, value string) {
 	}
 }
 
-// AddIfNotPresent Adds and env variable to a container if not already present. Returns true if the variable didn't exist
+// AddEnvIfNotPresent Adds and env variable to a container if not already present. Returns true if the variable didn't exist
 // and was added, false in any other case.
-func AddIfNotPresent(container *v1.Container, envVar v1.EnvVar) bool {
+func AddEnvIfNotPresent(container *v1.Container, envVar v1.EnvVar) bool {
 	for i := range container.Env {
 		if container.Env[i].Name == envVar.Name {
 			return false

--- a/utils/kubernetes/env_test.go
+++ b/utils/kubernetes/env_test.go
@@ -56,3 +56,24 @@ func TestCreateOrReplaceEnv(t *testing.T) {
 	CreateOrReplaceEnv(&containerWithEnv.Spec.Template.Spec.Containers[0], "myvar", "mutated")
 	assert.Equal(t, "mutated", containerWithEnv.Spec.Template.Spec.Containers[0].Env[0].Value)
 }
+
+func TestAddIfNotPresent(t *testing.T) {
+	containerNoEnv := &v1.Container{Env: nil}
+
+	wasAdded := AddIfNotPresent(containerNoEnv, v1.EnvVar{Name: "var1", Value: "value1"})
+	assert.True(t, wasAdded)
+	assert.Equal(t, v1.EnvVar{Name: "var1", Value: "value1"}, containerNoEnv.Env[0])
+
+	containerWithEnv := &v1.Container{Env: []v1.EnvVar{{Name: "var1", Value: "value1"}, {Name: "var2", Value: "value2"}}}
+	wasAdded = AddIfNotPresent(containerWithEnv, v1.EnvVar{Name: "var1", Value: "value1Changed"})
+	assert.False(t, wasAdded)
+	assert.Equal(t, v1.EnvVar{Name: "var1", Value: "value1"}, containerWithEnv.Env[0])
+	assert.Equal(t, v1.EnvVar{Name: "var2", Value: "value2"}, containerWithEnv.Env[1])
+
+	wasAdded = AddIfNotPresent(containerWithEnv, v1.EnvVar{Name: "var3", Value: "value3"})
+	assert.True(t, wasAdded)
+
+	assert.Equal(t, v1.EnvVar{Name: "var1", Value: "value1"}, containerWithEnv.Env[0])
+	assert.Equal(t, v1.EnvVar{Name: "var2", Value: "value2"}, containerWithEnv.Env[1])
+	assert.Equal(t, v1.EnvVar{Name: "var3", Value: "value3"}, containerWithEnv.Env[2])
+}

--- a/utils/kubernetes/env_test.go
+++ b/utils/kubernetes/env_test.go
@@ -60,17 +60,17 @@ func TestCreateOrReplaceEnv(t *testing.T) {
 func TestAddIfNotPresent(t *testing.T) {
 	containerNoEnv := &v1.Container{Env: nil}
 
-	wasAdded := AddIfNotPresent(containerNoEnv, v1.EnvVar{Name: "var1", Value: "value1"})
+	wasAdded := AddEnvIfNotPresent(containerNoEnv, v1.EnvVar{Name: "var1", Value: "value1"})
 	assert.True(t, wasAdded)
 	assert.Equal(t, v1.EnvVar{Name: "var1", Value: "value1"}, containerNoEnv.Env[0])
 
 	containerWithEnv := &v1.Container{Env: []v1.EnvVar{{Name: "var1", Value: "value1"}, {Name: "var2", Value: "value2"}}}
-	wasAdded = AddIfNotPresent(containerWithEnv, v1.EnvVar{Name: "var1", Value: "value1Changed"})
+	wasAdded = AddEnvIfNotPresent(containerWithEnv, v1.EnvVar{Name: "var1", Value: "value1Changed"})
 	assert.False(t, wasAdded)
 	assert.Equal(t, v1.EnvVar{Name: "var1", Value: "value1"}, containerWithEnv.Env[0])
 	assert.Equal(t, v1.EnvVar{Name: "var2", Value: "value2"}, containerWithEnv.Env[1])
 
-	wasAdded = AddIfNotPresent(containerWithEnv, v1.EnvVar{Name: "var3", Value: "value3"})
+	wasAdded = AddEnvIfNotPresent(containerWithEnv, v1.EnvVar{Name: "var3", Value: "value3"})
 	assert.True(t, wasAdded)
 
 	assert.Equal(t, v1.EnvVar{Name: "var1", Value: "value1"}, containerWithEnv.Env[0])


### PR DESCRIPTION

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>