### PR TITLE
kie-kogito-serverless-operator-441: Make the SonataFlowBuild smarter to manage persistence related extensions/props based on configuration

### DIFF
--- a/controllers/builder/containerbuilder.go
+++ b/controllers/builder/containerbuilder.go
@@ -22,6 +22,10 @@ package builder
 import (
 	"time"
 
+	"github.com/apache/incubator-kie-kogito-serverless-operator/workflowproj"
+
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/cfg"
 	"k8s.io/klog/v2"
 
@@ -52,6 +56,7 @@ type kanikoBuildInput struct {
 	task               *api.KanikoTask
 	workflowDefinition []byte
 	workflow           *operatorapi.SonataFlow
+	workflowProperties []operatorapi.ConfigMapWorkflowResource
 	dockerfile         string
 	imageTag           string
 }
@@ -139,6 +144,7 @@ func (c *containerBuilderManager) scheduleNewKanikoBuildWithContainerFile(build 
 		task:               task,
 		workflowDefinition: workflowDef,
 		workflow:           workflow,
+		workflowProperties: buildWorkflowPropertyResources(workflow),
 		dockerfile:         platform.GetCustomizedBuilderDockerfile(c.builderConfigMap.Data[defaultBuilderResourceName], *c.platform),
 		imageTag:           buildNamespacedImageTag(workflow),
 	}
@@ -200,6 +206,12 @@ func newBuild(buildInput kanikoBuildInput, platform api.PlatformContainerBuild, 
 		newBuilder.AddConfigMapResource(res.ConfigMap, res.WorkflowPath)
 	}
 
+	//TODO WM, remove this comment.
+	//make the workflow properties available to the kaniko build.
+	for _, props := range buildInput.workflowProperties {
+		newBuilder.AddConfigMapResource(props.ConfigMap, props.WorkflowPath)
+	}
+
 	return newBuilder.Scheduler().
 		WithAdditionalArgs(buildInput.task.AdditionalFlags).
 		WithResourceRequirements(buildInput.task.Resources).
@@ -212,4 +224,11 @@ func newBuild(buildInput kanikoBuildInput, platform api.PlatformContainerBuild, 
 // ImageStreams are already namespaced.
 func buildNamespacedImageTag(workflow *operatorapi.SonataFlow) string {
 	return workflow.Namespace + "/" + workflowdef.GetWorkflowAppImageNameTag(workflow)
+}
+
+func buildWorkflowPropertyResources(workflow *operatorapi.SonataFlow) []operatorapi.ConfigMapWorkflowResource {
+	return []operatorapi.ConfigMapWorkflowResource{
+		{ConfigMap: corev1.LocalObjectReference{Name: workflowproj.GetWorkflowUserPropertiesConfigMapName(workflow)}, WorkflowPath: ""},
+		{ConfigMap: corev1.LocalObjectReference{Name: workflowproj.GetWorkflowManagedPropertiesConfigMapName(workflow)}, WorkflowPath: ""},
+	}
 }

--- a/controllers/builder/kogitoserverlessbuild_manager.go
+++ b/controllers/builder/kogitoserverlessbuild_manager.go
@@ -21,7 +21,11 @@ package builder
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/profiles/common/persistence"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -29,6 +33,11 @@ import (
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/platform"
 
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+)
+
+const (
+	QuarkusExtensionsBuildArg = "QUARKUS_EXTENSIONS"
+	MavenAgsAppendBuildArg    = "MAVEN_ARGS_APPEND"
 )
 
 var _ SonataFlowBuildManager = &sonataFlowBuildManager{}
@@ -54,7 +63,21 @@ func (k *sonataFlowBuildManager) GetOrCreateBuild(workflow *operatorapi.SonataFl
 			if plat, err = platform.GetActivePlatform(k.ctx, k.client, workflow.Namespace); err != nil {
 				return nil, err
 			}
-			buildInstance.Spec.BuildTemplate = plat.Spec.Build.Template
+			fmt.Println("XXXX original build template")
+			fmt.Println(plat.Spec.Build.Template)
+
+			workflowBuildTemplate := plat.Spec.Build.Template.DeepCopy()
+			if workflow.Spec.Persistence != nil && workflow.Spec.Persistence.PostgreSQL != nil {
+				//TODO WM, remove this comment
+				//smart adding of the required persistence extensions and must the must have quarkus build-time properties.
+				addPersistenceExtensions(workflowBuildTemplate)
+				addPersistenceMavenArgs(workflowBuildTemplate)
+			}
+
+			buildInstance.Spec.BuildTemplate = *workflowBuildTemplate
+			fmt.Println("XXXX modified build template")
+			fmt.Println(buildInstance.Spec.BuildTemplate.BuildArgs)
+
 			if err = controllerutil.SetControllerReference(workflow, buildInstance, k.client.Scheme()); err != nil {
 				return nil, err
 			}
@@ -85,4 +108,77 @@ func NewSonataFlowBuildManager(ctx context.Context, client client.Client) Sonata
 		client: client,
 		ctx:    ctx,
 	}
+}
+
+// addPersistenceExtensions Adds the persistence related extensions to the current BuildTemplate if none of them is
+// already provided. If any of them is detected, means that users might already have provided them in the
+// SonataFlowPlatform, so we just let the provided configuration.
+func addPersistenceExtensions(template *operatorapi.BuildTemplate) {
+	quarkusExtensions := getBuildArg(template.BuildArgs, QuarkusExtensionsBuildArg)
+	if quarkusExtensions == nil {
+		template.BuildArgs = append(template.BuildArgs, v1.EnvVar{Name: QuarkusExtensionsBuildArg})
+		quarkusExtensions = &template.BuildArgs[len(template.BuildArgs)-1]
+	}
+	if !hasAnyExtensionPresent(quarkusExtensions, persistence.GetPostgreSQLExtensions()) {
+		for _, extension := range persistence.GetPostgreSQLExtensions() {
+			if len(quarkusExtensions.Value) > 0 {
+				quarkusExtensions.Value = quarkusExtensions.Value + ","
+			}
+			quarkusExtensions.Value = quarkusExtensions.Value + extension.String()
+		}
+	}
+}
+
+// addPersistenceMavenArgs Adds the persistence related build time properties to the current BuildTemplate if none of
+// them is already provided. If any of them is detected, means that users might already have provided them in the
+// SonataFlowPlatform, so we just let the provided configuration.
+func addPersistenceMavenArgs(template *operatorapi.BuildTemplate) {
+	mavenArgs := getBuildArg(template.BuildArgs, MavenAgsAppendBuildArg)
+	if mavenArgs == nil {
+		template.BuildArgs = append(template.BuildArgs, v1.EnvVar{Name: MavenAgsAppendBuildArg})
+		mavenArgs = &template.BuildArgs[len(template.BuildArgs)-1]
+	}
+	if !hasAnyArgPresent(mavenArgs, persistence.GetPostgreSQLBuildProperties()) {
+		for _, property := range persistence.GetPostgreSQLBuildProperties() {
+			if len(mavenArgs.Value) > 0 {
+				mavenArgs.Value = mavenArgs.Value + " "
+			}
+			mavenArgs.Value = mavenArgs.Value + fmt.Sprintf("-D%s=%s", property.Name(), property.Value())
+		}
+	}
+}
+
+func getBuildArg(buildArgs []v1.EnvVar, name string) *v1.EnvVar {
+	for i := 0; i < len(buildArgs); i++ {
+		if buildArgs[i].Name == name {
+			return &buildArgs[i]
+		}
+	}
+	return nil
+}
+
+func hasAnyExtensionPresent(buildArg *v1.EnvVar, extensions []persistence.GAV) bool {
+	for _, extension := range extensions {
+		if isExtensionPresent(buildArg, extension) {
+			return true
+		}
+	}
+	return false
+}
+
+func isExtensionPresent(buildArg *v1.EnvVar, extension persistence.GAV) bool {
+	return strings.Contains(buildArg.Value, extension.GroupAndArtifact())
+}
+
+func hasAnyArgPresent(args *v1.EnvVar, properties []persistence.Property) bool {
+	for _, property := range properties {
+		if isPropertyPresent(args, property) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPropertyPresent(args *v1.EnvVar, property persistence.Property) bool {
+	return strings.Contains(args.Value, fmt.Sprintf("-D%s=", property.Name()))
 }

--- a/controllers/builder/openshiftbuilder.go
+++ b/controllers/builder/openshiftbuilder.go
@@ -196,6 +196,15 @@ func (o *openshiftBuilderManager) addExternalResources(config *buildv1.BuildConf
 			DestinationDir: workflowRes.WorkflowPath,
 		})
 	}
+	//TODO WM remove this comment
+	//make the workflow properties available to the OpenShift build config.
+	configMapSources = append(configMapSources, buildv1.ConfigMapBuildSource{
+		ConfigMap:      corev1.LocalObjectReference{Name: workflowproj.GetWorkflowUserPropertiesConfigMapName(workflow)},
+		DestinationDir: ""})
+	configMapSources = append(configMapSources, buildv1.ConfigMapBuildSource{
+		ConfigMap:      corev1.LocalObjectReference{Name: workflowproj.GetWorkflowManagedPropertiesConfigMapName(workflow)},
+		DestinationDir: ""})
+
 	config.Spec.Source.ConfigMaps = configMapSources
 	return nil
 }

--- a/controllers/profiles/common/persistence/postgresql.go
+++ b/controllers/profiles/common/persistence/postgresql.go
@@ -17,11 +17,10 @@ package persistence
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/profiles/common/constants"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -40,6 +39,34 @@ const (
 	defaultPostgreSQLUsername  = "sonataflow"
 	defaultPostgresSQLPassword = "sonataflow"
 )
+
+// TODO WM, move to a better place
+type GAV struct {
+	groupId    string
+	artifactId string
+	version    string
+}
+
+type Property struct {
+	name  string
+	value string
+}
+
+func (g *GAV) GroupAndArtifact() string {
+	return fmt.Sprintf("%s:%s", g.groupId, g.artifactId)
+}
+
+func (g *GAV) String() string {
+	return fmt.Sprintf("%s:%s:%s", g.groupId, g.artifactId, g.version)
+}
+
+func (p *Property) Name() string {
+	return p.name
+}
+
+func (p *Property) Value() string {
+	return p.value
+}
 
 func ConfigurePostgreSQLEnv(postgresql *operatorapi.PersistencePostgreSQL, databaseSchema, databaseNamespace string) []corev1.EnvVar {
 	dataSourcePort := constants.DefaultPostgreSQLPort
@@ -144,4 +171,21 @@ func RetrieveConfiguration(primary *v1alpha08.PersistenceOptionsSpec, platformPe
 		}
 	}
 	return c
+}
+
+func GetPostgreSQLExtensions() []GAV {
+	//TODO WM
+	//we need a smart way to distinguish the artifacts in case we have different ones for product/community release.
+	return []GAV{
+		{"io.quarkus", "quarkus-jdbc-postgresql", "3.2.10.Final"},
+		{"io.quarkus", "quarkus-agroal", "3.2.10.Final"},
+		{"org.kie", "kie-addons-quarkus-persistence-jdbc", "999-SNAPSHOT"},
+	}
+}
+
+func GetPostgreSQLBuildProperties() []Property {
+	return []Property{
+		{"kogito.persistence.type", "jdbc"},
+		{"kogito.persistence.proto.marshaller", "false"},
+	}
 }

--- a/controllers/profiles/preview/profile_preview.go
+++ b/controllers/profiles/preview/profile_preview.go
@@ -79,7 +79,7 @@ func NewProfileReconciler(client client.Client, cfg *rest.Config, recorder recor
 	}
 	// the reconciliation state machine
 	stateMachine := common.NewReconciliationStateMachine(
-		&newBuilderState{StateSupport: support},
+		&newBuilderState{StateSupport: support, ensurers: NewObjectEnsurers(support)},
 		&followBuildStatusState{StateSupport: support},
 		&deployWithBuildWorkflowState{StateSupport: support, ensurers: NewObjectEnsurers(support)},
 	)


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>