### PR TITLE
kie-kogito-serverless-operator-441: Make the SonataFlowBuild smarter to manage persistence related extensions/props based on configuration

### DIFF
--- a/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
+++ b/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
@@ -29,6 +29,18 @@ data:
     sonataFlowDevModeImageTag: ""
     # The default name of the builder configMap in the operator's namespace
     builderConfigMapName: "sonataflow-operator-builder-config"
+    # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
+    # in cases where the workflow being built has configured postgresql persistence.
+    postgreSQLPersistenceExtensions:
+      - groupId: "io.quarkus"
+        artifactId: quarkus-jdbc-postgresql
+        version: 3.2.10.Final
+      - groupId: io.quarkus
+        artifactId: quarkus-agroal
+        version: 3.2.10.Final
+      - groupId: org.kie
+        artifactId: kie-addons-quarkus-persistence-jdbc
+        version: 999-SNAPSHOT
 kind: ConfigMap
 metadata:
   name: sonataflow-operator-controllers-config

--- a/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
+++ b/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
@@ -32,7 +32,7 @@ data:
     # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
     # in cases where the workflow being built has configured postgresql persistence.
     postgreSQLPersistenceExtensions:
-      - groupId: "io.quarkus"
+      - groupId: io.quarkus
         artifactId: quarkus-jdbc-postgresql
         version: 3.2.10.Final
       - groupId: io.quarkus

--- a/config/manager/controllers_cfg.yaml
+++ b/config/manager/controllers_cfg.yaml
@@ -29,7 +29,7 @@ builderConfigMapName: "sonataflow-operator-builder-config"
 # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
 # in cases where the workflow being built has configured postgresql persistence.
 postgreSQLPersistenceExtensions:
-  - groupId: "io.quarkus"
+  - groupId: io.quarkus
     artifactId: quarkus-jdbc-postgresql
     version: 3.2.10.Final
   - groupId: io.quarkus

--- a/config/manager/controllers_cfg.yaml
+++ b/config/manager/controllers_cfg.yaml
@@ -26,3 +26,15 @@ sonataFlowBaseBuilderImageTag: ""
 sonataFlowDevModeImageTag: ""
 # The default name of the builder configMap in the operator's namespace
 builderConfigMapName: "sonataflow-operator-builder-config"
+# Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
+# in cases where the workflow being built has configured postgresql persistence.
+postgreSQLPersistenceExtensions:
+  - groupId: "io.quarkus"
+    artifactId: quarkus-jdbc-postgresql
+    version: 3.2.10.Final
+  - groupId: io.quarkus
+    artifactId: quarkus-agroal
+    version: 3.2.10.Final
+  - groupId: org.kie
+    artifactId: kie-addons-quarkus-persistence-jdbc
+    version: 999-SNAPSHOT

--- a/controllers/builder/kogitoserverlessbuild_manager_test.go
+++ b/controllers/builder/kogitoserverlessbuild_manager_test.go
@@ -15,6 +15,8 @@
 package builder
 
 import (
+	"testing"
+
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/cfg"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/profiles/common/persistence"
@@ -22,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestSonataFlowBuildManager_GetOrCreateBuildWithWorkflowPersistence(t *testing.T) {

--- a/controllers/builder/kogitoserverlessbuild_manager_test.go
+++ b/controllers/builder/kogitoserverlessbuild_manager_test.go
@@ -86,6 +86,7 @@ func TestSonataFlowBuildManager_GetOrCreateBuildWithNoPersistence(t *testing.T) 
 	buildManager := prepareGetOrCreateBuildTest(t, &currentPlatform)
 	build, _ := buildManager.GetOrCreateBuild(&workflow)
 	assert.Equal(t, 0, len(build.Spec.BuildArgs))
+	restoreControllersConfig(t)
 }
 
 func testGetOrCreateBuildWithPersistence(t *testing.T, currentPlatform *operatorapi.SonataFlowPlatform, workflow *operatorapi.SonataFlow) {
@@ -94,6 +95,7 @@ func testGetOrCreateBuildWithPersistence(t *testing.T, currentPlatform *operator
 	assert.NotNil(t, build)
 	assert.Equal(t, 1, len(build.Spec.BuildArgs))
 	assertContainsPersistence(t, build.Spec.BuildArgs, 0)
+	restoreControllersConfig(t)
 }
 
 func prepareGetOrCreateBuildTest(t *testing.T, currentPlatform *operatorapi.SonataFlowPlatform) sonataFlowBuildManager {
@@ -113,6 +115,7 @@ func Test_addPersistenceExtensionsWithEmptyArgs(t *testing.T) {
 	addPersistenceExtensions(buildTemplate)
 	assert.Equal(t, 1, len(buildTemplate.BuildArgs))
 	assertContainsPersistence(t, buildTemplate.BuildArgs, 0)
+	restoreControllersConfig(t)
 }
 
 func Test_addPersistenceExtensionsWithNoQuarkusExtensionsArg(t *testing.T) {
@@ -125,6 +128,7 @@ func Test_addPersistenceExtensionsWithNoQuarkusExtensionsArg(t *testing.T) {
 	addPersistenceExtensions(buildTemplate)
 	assert.Equal(t, 2, len(buildTemplate.BuildArgs))
 	assertContainsPersistence(t, buildTemplate.BuildArgs, 1)
+	restoreControllersConfig(t)
 }
 
 func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndNoPersistenceExtensions(t *testing.T) {
@@ -138,7 +142,7 @@ func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndNoPersistenceExtens
 	addPersistenceExtensions(buildTemplate)
 	assert.Equal(t, 2, len(buildTemplate.BuildArgs))
 	assertContainsPersistence(t, buildTemplate.BuildArgs, 1)
-
+	restoreControllersConfig(t)
 }
 
 func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndPersistenceExtensions(t *testing.T) {
@@ -153,6 +157,7 @@ func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndPersistenceExtensio
 	assert.Equal(t, 2, len(buildTemplate.BuildArgs))
 	assert.Equal(t, v1.EnvVar{Name: "VAR1", Value: "VALUE1"}, buildTemplate.BuildArgs[0])
 	assert.Equal(t, v1.EnvVar{Name: "QUARKUS_EXTENSIONS", Value: "org.acme:org.acme.library:1.0.0,io.quarkus:quarkus-jdbc-postgresql:8.8.0.Final"}, buildTemplate.BuildArgs[1])
+	restoreControllersConfig(t)
 }
 
 func initializeControllersConfig(t *testing.T) {
@@ -161,6 +166,13 @@ func initializeControllersConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, 3, len(cfg.PostgreSQLPersistenceExtensions))
+}
+
+func restoreControllersConfig(t *testing.T) {
+	// restore the controllers configuration to default values since it's a global configuration, and we don't
+	// want current test interfere with other tests.
+	_, err := cfg.InitializeControllersCfgAt("../../config/manager/controllers_cfg.yaml")
+	assert.NoError(t, err)
 }
 
 func assertContainsPersistence(t *testing.T, buildArgs []v1.EnvVar, position int) {

--- a/controllers/builder/kogitoserverlessbuild_manager_test.go
+++ b/controllers/builder/kogitoserverlessbuild_manager_test.go
@@ -86,7 +86,7 @@ func TestSonataFlowBuildManager_GetOrCreateBuildWithNoPersistence(t *testing.T) 
 	buildManager := prepareGetOrCreateBuildTest(t, &currentPlatform)
 	build, _ := buildManager.GetOrCreateBuild(&workflow)
 	assert.Equal(t, 0, len(build.Spec.BuildArgs))
-	restoreControllersConfig(t)
+	test.RestoreControllersConfig(t)
 }
 
 func testGetOrCreateBuildWithPersistence(t *testing.T, currentPlatform *operatorapi.SonataFlowPlatform, workflow *operatorapi.SonataFlow) {
@@ -95,7 +95,7 @@ func testGetOrCreateBuildWithPersistence(t *testing.T, currentPlatform *operator
 	assert.NotNil(t, build)
 	assert.Equal(t, 1, len(build.Spec.BuildArgs))
 	assertContainsPersistence(t, build.Spec.BuildArgs, 0)
-	restoreControllersConfig(t)
+	test.RestoreControllersConfig(t)
 }
 
 func prepareGetOrCreateBuildTest(t *testing.T, currentPlatform *operatorapi.SonataFlowPlatform) sonataFlowBuildManager {
@@ -115,7 +115,7 @@ func Test_addPersistenceExtensionsWithEmptyArgs(t *testing.T) {
 	addPersistenceExtensions(buildTemplate)
 	assert.Equal(t, 1, len(buildTemplate.BuildArgs))
 	assertContainsPersistence(t, buildTemplate.BuildArgs, 0)
-	restoreControllersConfig(t)
+	test.RestoreControllersConfig(t)
 }
 
 func Test_addPersistenceExtensionsWithNoQuarkusExtensionsArg(t *testing.T) {
@@ -128,7 +128,7 @@ func Test_addPersistenceExtensionsWithNoQuarkusExtensionsArg(t *testing.T) {
 	addPersistenceExtensions(buildTemplate)
 	assert.Equal(t, 2, len(buildTemplate.BuildArgs))
 	assertContainsPersistence(t, buildTemplate.BuildArgs, 1)
-	restoreControllersConfig(t)
+	test.RestoreControllersConfig(t)
 }
 
 func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndNoPersistenceExtensions(t *testing.T) {
@@ -142,7 +142,7 @@ func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndNoPersistenceExtens
 	addPersistenceExtensions(buildTemplate)
 	assert.Equal(t, 2, len(buildTemplate.BuildArgs))
 	assertContainsPersistence(t, buildTemplate.BuildArgs, 1)
-	restoreControllersConfig(t)
+	test.RestoreControllersConfig(t)
 }
 
 func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndPersistenceExtensions(t *testing.T) {
@@ -157,7 +157,7 @@ func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndPersistenceExtensio
 	assert.Equal(t, 2, len(buildTemplate.BuildArgs))
 	assert.Equal(t, v1.EnvVar{Name: "VAR1", Value: "VALUE1"}, buildTemplate.BuildArgs[0])
 	assert.Equal(t, v1.EnvVar{Name: "QUARKUS_EXTENSIONS", Value: "org.acme:org.acme.library:1.0.0,io.quarkus:quarkus-jdbc-postgresql:8.8.0.Final"}, buildTemplate.BuildArgs[1])
-	restoreControllersConfig(t)
+	test.RestoreControllersConfig(t)
 }
 
 func initializeControllersConfig(t *testing.T) {
@@ -166,13 +166,6 @@ func initializeControllersConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, 3, len(cfg.PostgreSQLPersistenceExtensions))
-}
-
-func restoreControllersConfig(t *testing.T) {
-	// restore the controllers configuration to default values since it's a global configuration, and we don't
-	// want current test interfere with other tests.
-	_, err := cfg.InitializeControllersCfgAt("../../config/manager/controllers_cfg.yaml")
-	assert.NoError(t, err)
 }
 
 func assertContainsPersistence(t *testing.T, buildArgs []v1.EnvVar, position int) {

--- a/controllers/builder/kogitoserverlessbuild_manager_test.go
+++ b/controllers/builder/kogitoserverlessbuild_manager_test.go
@@ -1,0 +1,172 @@
+// Copyright 2024 Apache Software Foundation (ASF)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/cfg"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/profiles/common/persistence"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/test"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestSonataFlowBuildManager_GetOrCreateBuildWithWorkflowPersistence(t *testing.T) {
+	// Current platform with no persistence
+	currentPlatform := operatorapi.SonataFlowPlatform{
+		ObjectMeta: metav1.ObjectMeta{Name: "current-platform"},
+		Spec:       operatorapi.SonataFlowPlatformSpec{},
+		Status:     operatorapi.SonataFlowPlatformStatus{},
+	}
+	// Persistence is configured in the workflow
+	workflow := operatorapi.SonataFlow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-workflow",
+		},
+		Spec: operatorapi.SonataFlowSpec{
+			Persistence: &operatorapi.PersistenceOptionsSpec{
+				PostgreSQL: &operatorapi.PersistencePostgreSQL{},
+			},
+		},
+		Status: operatorapi.SonataFlowStatus{},
+	}
+	testGetOrCreateBuildWithPersistence(t, &currentPlatform, &workflow)
+}
+
+func TestSonataFlowBuildManager_GetOrCreateBuildWithPlatformPersistence(t *testing.T) {
+	// Persistence is configured in the platform
+	currentPlatform := operatorapi.SonataFlowPlatform{
+		ObjectMeta: metav1.ObjectMeta{Name: "current-platform"},
+		Spec: operatorapi.SonataFlowPlatformSpec{
+			Persistence: &operatorapi.PlatformPersistenceOptionsSpec{
+				PostgreSQL: &operatorapi.PlatformPersistencePostgreSQL{},
+			},
+		},
+		Status: operatorapi.SonataFlowPlatformStatus{},
+	}
+	// Workflow with no persistence
+	workflow := operatorapi.SonataFlow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-workflow",
+		},
+		Status: operatorapi.SonataFlowStatus{},
+	}
+	testGetOrCreateBuildWithPersistence(t, &currentPlatform, &workflow)
+}
+
+func TestSonataFlowBuildManager_GetOrCreateBuildWithNoPersistence(t *testing.T) {
+	// Platform has no persistence
+	currentPlatform := operatorapi.SonataFlowPlatform{
+		ObjectMeta: metav1.ObjectMeta{Name: "current-platform"},
+		Spec:       operatorapi.SonataFlowPlatformSpec{},
+		Status:     operatorapi.SonataFlowPlatformStatus{},
+	}
+	// Workflow has no persistence
+	workflow := operatorapi.SonataFlow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-workflow",
+		},
+		Status: operatorapi.SonataFlowStatus{},
+	}
+	buildManager := prepareGetOrCreateBuildTest(t, &currentPlatform)
+	build, _ := buildManager.GetOrCreateBuild(&workflow)
+	assert.Equal(t, 0, len(build.Spec.BuildArgs))
+}
+
+func testGetOrCreateBuildWithPersistence(t *testing.T, currentPlatform *operatorapi.SonataFlowPlatform, workflow *operatorapi.SonataFlow) {
+	buildManager := prepareGetOrCreateBuildTest(t, currentPlatform)
+	build, _ := buildManager.GetOrCreateBuild(workflow)
+	assert.NotNil(t, build)
+	assert.Equal(t, 1, len(build.Spec.BuildArgs))
+	assertContainsPersistence(t, build.Spec.BuildArgs, 0)
+}
+
+func prepareGetOrCreateBuildTest(t *testing.T, currentPlatform *operatorapi.SonataFlowPlatform) sonataFlowBuildManager {
+	initializeControllersConfig(t)
+	platforms := operatorapi.NewSonataFlowPlatformList()
+	platforms.Items = []operatorapi.SonataFlowPlatform{*currentPlatform}
+	cli := test.NewSonataFlowClientBuilder().WithRuntimeObjects(&platforms).Build()
+	buildManager := sonataFlowBuildManager{
+		client: cli,
+	}
+	return buildManager
+}
+
+func Test_addPersistenceExtensionsWithEmptyArgs(t *testing.T) {
+	initializeControllersConfig(t)
+	buildTemplate := &operatorapi.BuildTemplate{}
+	addPersistenceExtensions(buildTemplate)
+	assert.Equal(t, 1, len(buildTemplate.BuildArgs))
+	assertContainsPersistence(t, buildTemplate.BuildArgs, 0)
+}
+
+func Test_addPersistenceExtensionsWithNoQuarkusExtensionsArg(t *testing.T) {
+	initializeControllersConfig(t)
+	buildTemplate := &operatorapi.BuildTemplate{
+		BuildArgs: []v1.EnvVar{
+			{Name: "VAR1"},
+		},
+	}
+	addPersistenceExtensions(buildTemplate)
+	assert.Equal(t, 2, len(buildTemplate.BuildArgs))
+	assertContainsPersistence(t, buildTemplate.BuildArgs, 1)
+}
+
+func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndNoPersistenceExtensions(t *testing.T) {
+	initializeControllersConfig(t)
+	buildTemplate := &operatorapi.BuildTemplate{
+		BuildArgs: []v1.EnvVar{
+			{Name: "VAR1"},
+			{Name: "QUARKUS_EXTENSIONS", Value: "org.acme:org.acme.library:1.0.0"},
+		},
+	}
+	addPersistenceExtensions(buildTemplate)
+	assert.Equal(t, 2, len(buildTemplate.BuildArgs))
+	assertContainsPersistence(t, buildTemplate.BuildArgs, 1)
+
+}
+
+func Test_addPersistenceExtensionsWithQuarkusExtensionsArgAndPersistenceExtensions(t *testing.T) {
+	initializeControllersConfig(t)
+	buildTemplate := &operatorapi.BuildTemplate{
+		BuildArgs: []v1.EnvVar{
+			{Name: "VAR1", Value: "VALUE1"},
+			{Name: "QUARKUS_EXTENSIONS", Value: "org.acme:org.acme.library:1.0.0,io.quarkus:quarkus-jdbc-postgresql:8.8.0.Final"},
+		},
+	}
+	addPersistenceExtensions(buildTemplate)
+	assert.Equal(t, 2, len(buildTemplate.BuildArgs))
+	assert.Equal(t, v1.EnvVar{Name: "VAR1", Value: "VALUE1"}, buildTemplate.BuildArgs[0])
+	assert.Equal(t, v1.EnvVar{Name: "QUARKUS_EXTENSIONS", Value: "org.acme:org.acme.library:1.0.0,io.quarkus:quarkus-jdbc-postgresql:8.8.0.Final"}, buildTemplate.BuildArgs[1])
+}
+
+func initializeControllersConfig(t *testing.T) {
+	// emulate the controllers config initialization
+	cfg, err := cfg.InitializeControllersCfgAt("../cfg/testdata/controllers-cfg-test.yaml")
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, 3, len(cfg.PostgreSQLPersistenceExtensions))
+}
+
+func assertContainsPersistence(t *testing.T, buildArgs []v1.EnvVar, position int) {
+	assert.GreaterOrEqual(t, len(buildArgs), position)
+	envVar := buildArgs[position]
+	assert.Equal(t, QuarkusExtensionsBuildArg, envVar.Name)
+	for _, extension := range persistence.GetPostgreSQLExtensions() {
+		assert.Contains(t, envVar.Value, extension.String())
+	}
+}

--- a/controllers/builder/openshiftbuilder.go
+++ b/controllers/builder/openshiftbuilder.go
@@ -186,9 +186,6 @@ func (o *openshiftBuilderManager) newDefaultBuildConfig(build *operatorapi.Sonat
 }
 
 func (o *openshiftBuilderManager) addExternalResources(config *buildv1.BuildConfig, workflow *operatorapi.SonataFlow) error {
-	if len(workflow.Spec.Resources.ConfigMaps) == 0 {
-		return nil
-	}
 	var configMapSources []buildv1.ConfigMapBuildSource
 	for _, workflowRes := range workflow.Spec.Resources.ConfigMaps {
 		configMapSources = append(configMapSources, buildv1.ConfigMapBuildSource{
@@ -196,6 +193,14 @@ func (o *openshiftBuilderManager) addExternalResources(config *buildv1.BuildConf
 			DestinationDir: workflowRes.WorkflowPath,
 		})
 	}
+	//make the workflow properties available to the OpenShift build config.
+	configMapSources = append(configMapSources, buildv1.ConfigMapBuildSource{
+		ConfigMap:      corev1.LocalObjectReference{Name: workflowproj.GetWorkflowUserPropertiesConfigMapName(workflow)},
+		DestinationDir: ""})
+	configMapSources = append(configMapSources, buildv1.ConfigMapBuildSource{
+		ConfigMap:      corev1.LocalObjectReference{Name: workflowproj.GetWorkflowManagedPropertiesConfigMapName(workflow)},
+		DestinationDir: ""})
+
 	config.Spec.Source.ConfigMaps = configMapSources
 	return nil
 }

--- a/controllers/builder/openshiftbuilder_test.go
+++ b/controllers/builder/openshiftbuilder_test.go
@@ -103,7 +103,7 @@ func Test_openshiftbuilder_externalCMs(t *testing.T) {
 		},
 	}
 	workflow.Spec.Resources.ConfigMaps = append(workflow.Spec.Resources.ConfigMaps,
-		operatorapi.ConfigMapWorkflowResource{ConfigMap: v1.LocalObjectReference{Name: externalCm.Name}})
+		operatorapi.ConfigMapWorkflowResource{ConfigMap: v1.LocalObjectReference{Name: externalCm.Name}, WorkflowPath: "specs"})
 
 	namespacedName := types.NamespacedName{Namespace: workflow.Namespace, Name: workflow.Name}
 	client := test.NewKogitoClientBuilderWithOpenShift().WithRuntimeObjects(workflow, platform, config, externalCm).Build()
@@ -129,7 +129,13 @@ func Test_openshiftbuilder_externalCMs(t *testing.T) {
 	bc := &buildv1.BuildConfig{}
 	assert.NoError(t, client.Get(context.TODO(), namespacedName, bc))
 
-	assert.Len(t, bc.Spec.Source.ConfigMaps, 1)
+	assert.Len(t, bc.Spec.Source.ConfigMaps, 3)
+	assert.Equal(t, "myopenapis", bc.Spec.Source.ConfigMaps[0].ConfigMap.Name)
+	assert.Equal(t, "specs", bc.Spec.Source.ConfigMaps[0].DestinationDir)
+	assert.Equal(t, "greeting-props", bc.Spec.Source.ConfigMaps[1].ConfigMap.Name)
+	assert.Equal(t, "", bc.Spec.Source.ConfigMaps[1].DestinationDir)
+	assert.Equal(t, "greeting-managed-props", bc.Spec.Source.ConfigMaps[2].ConfigMap.Name)
+	assert.Equal(t, "", bc.Spec.Source.ConfigMaps[2].DestinationDir)
 }
 
 func Test_openshiftbuilder_forcePull(t *testing.T) {

--- a/controllers/cfg/controllers_cfg.go
+++ b/controllers/cfg/controllers_cfg.go
@@ -18,6 +18,7 @@ package cfg
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 
 	"github.com/apache/incubator-kie-kogito-serverless-operator/log"
@@ -40,18 +41,25 @@ var defaultControllersCfg = &ControllersCfg{
 	BuilderConfigMapName:          "sonataflow-operator-builder-config",
 }
 
+type GAV struct {
+	GroupId    string `yaml:"GroupId,omitempty"`
+	ArtifactId string `yaml:"ArtifactId,omitempty"`
+	Version    string `yaml:"Version,omitempty"`
+}
+
 type ControllersCfg struct {
-	DefaultPvcKanikoSize          string `yaml:"defaultPvcKanikoSize,omitempty"`
-	HealthFailureThresholdDevMode int32  `yaml:"healthFailureThresholdDevMode,omitempty"`
-	KanikoDefaultWarmerImageTag   string `yaml:"kanikoDefaultWarmerImageTag,omitempty"`
-	KanikoExecutorImageTag        string `yaml:"kanikoExecutorImageTag,omitempty"`
-	JobsServicePostgreSQLImageTag string `yaml:"jobsServicePostgreSQLImageTag,omitempty"`
-	JobsServiceEphemeralImageTag  string `yaml:"jobsServiceEphemeralImageTag,omitempty"`
-	DataIndexPostgreSQLImageTag   string `yaml:"dataIndexPostgreSQLImageTag,omitempty"`
-	DataIndexEphemeralImageTag    string `yaml:"dataIndexEphemeralImageTag,omitempty"`
-	SonataFlowBaseBuilderImageTag string `yaml:"sonataFlowBaseBuilderImageTag,omitempty"`
-	SonataFlowDevModeImageTag     string `yaml:"sonataFlowDevModeImageTag,omitempty"`
-	BuilderConfigMapName          string `yaml:"builderConfigMapName,omitempty"`
+	DefaultPvcKanikoSize            string `yaml:"defaultPvcKanikoSize,omitempty"`
+	HealthFailureThresholdDevMode   int32  `yaml:"healthFailureThresholdDevMode,omitempty"`
+	KanikoDefaultWarmerImageTag     string `yaml:"kanikoDefaultWarmerImageTag,omitempty"`
+	KanikoExecutorImageTag          string `yaml:"kanikoExecutorImageTag,omitempty"`
+	JobsServicePostgreSQLImageTag   string `yaml:"jobsServicePostgreSQLImageTag,omitempty"`
+	JobsServiceEphemeralImageTag    string `yaml:"jobsServiceEphemeralImageTag,omitempty"`
+	DataIndexPostgreSQLImageTag     string `yaml:"dataIndexPostgreSQLImageTag,omitempty"`
+	DataIndexEphemeralImageTag      string `yaml:"dataIndexEphemeralImageTag,omitempty"`
+	SonataFlowBaseBuilderImageTag   string `yaml:"sonataFlowBaseBuilderImageTag,omitempty"`
+	SonataFlowDevModeImageTag       string `yaml:"sonataFlowDevModeImageTag,omitempty"`
+	BuilderConfigMapName            string `yaml:"builderConfigMapName,omitempty"`
+	PostgreSQLPersistenceExtensions []GAV  `yaml:"postgreSQLPersistenceExtensions,omitempty"`
 }
 
 // InitializeControllersCfg initializes the platform configuration for this instance.
@@ -92,4 +100,12 @@ func GetCfg() *ControllersCfg {
 		return defaultControllersCfg
 	}
 	return controllersCfg
+}
+
+func (g *GAV) GroupAndArtifact() string {
+	return fmt.Sprintf("%s:%s", g.GroupId, g.ArtifactId)
+}
+
+func (g *GAV) String() string {
+	return fmt.Sprintf("%s:%s:%s", g.GroupId, g.ArtifactId, g.Version)
 }

--- a/controllers/cfg/controllers_cfg.go
+++ b/controllers/cfg/controllers_cfg.go
@@ -42,9 +42,17 @@ var defaultControllersCfg = &ControllersCfg{
 }
 
 type GAV struct {
-	GroupId    string `yaml:"GroupId,omitempty"`
-	ArtifactId string `yaml:"ArtifactId,omitempty"`
-	Version    string `yaml:"Version,omitempty"`
+	GroupId    string `yaml:"groupId,omitempty"`
+	ArtifactId string `yaml:"artifactId,omitempty"`
+	Version    string `yaml:"version,omitempty"`
+}
+
+func (g *GAV) GroupAndArtifact() string {
+	return fmt.Sprintf("%s:%s", g.GroupId, g.ArtifactId)
+}
+
+func (g *GAV) String() string {
+	return fmt.Sprintf("%s:%s:%s", g.GroupId, g.ArtifactId, g.Version)
 }
 
 type ControllersCfg struct {
@@ -100,12 +108,4 @@ func GetCfg() *ControllersCfg {
 		return defaultControllersCfg
 	}
 	return controllersCfg
-}
-
-func (g *GAV) GroupAndArtifact() string {
-	return fmt.Sprintf("%s:%s", g.GroupId, g.ArtifactId)
-}
-
-func (g *GAV) String() string {
-	return fmt.Sprintf("%s:%s:%s", g.GroupId, g.ArtifactId, g.Version)
 }

--- a/controllers/cfg/controllers_cfg_test.go
+++ b/controllers/cfg/controllers_cfg_test.go
@@ -32,6 +32,25 @@ func TestInitializeControllersCfgAt_ValidFile(t *testing.T) {
 	assert.Equal(t, "local/data-index:1.0.0", cfg.DataIndexPostgreSQLImageTag)
 	assert.Equal(t, "local/sonataflow-builder:1.0.0", cfg.SonataFlowBaseBuilderImageTag)
 	assert.Equal(t, "local/sonataflow-devmode:1.0.0", cfg.SonataFlowDevModeImageTag)
+	assert.Equal(t, 3, len(cfg.PostgreSQLPersistenceExtensions))
+	postgresExtensions := cfg.PostgreSQLPersistenceExtensions
+	assert.Equal(t, GAV{
+		GroupId:    "io.quarkus",
+		ArtifactId: "quarkus-jdbc-postgresql",
+		Version:    "3.2.10.Final",
+	}, postgresExtensions[0])
+
+	assert.Equal(t, GAV{
+		GroupId:    "io.quarkus",
+		ArtifactId: "quarkus-agroal",
+		Version:    "3.2.10.Final",
+	}, postgresExtensions[1])
+
+	assert.Equal(t, GAV{
+		GroupId:    "org.kie",
+		ArtifactId: "kie-addons-quarkus-persistence-jdbc",
+		Version:    "999-SNAPSHOT",
+	}, postgresExtensions[2])
 }
 
 func TestInitializeControllersCfgAt_FileNotFound(t *testing.T) {

--- a/controllers/cfg/testdata/controllers-cfg-test.yaml
+++ b/controllers/cfg/testdata/controllers-cfg-test.yaml
@@ -22,7 +22,7 @@ dataIndexPostgreSQLImageTag: "local/data-index:1.0.0"
 sonataFlowBaseBuilderImageTag: "local/sonataflow-builder:1.0.0"
 sonataFlowDevModeImageTag: "local/sonataflow-devmode:1.0.0"
 postgreSQLPersistenceExtensions:
-  - groupId: "io.quarkus"
+  - groupId: io.quarkus
     artifactId: quarkus-jdbc-postgresql
     version: 3.2.10.Final
   - groupId: io.quarkus

--- a/controllers/cfg/testdata/controllers-cfg-test.yaml
+++ b/controllers/cfg/testdata/controllers-cfg-test.yaml
@@ -21,3 +21,13 @@ jobsServicePostgreSQLImageTag: "local/jobs-service:1.0.0"
 dataIndexPostgreSQLImageTag: "local/data-index:1.0.0"
 sonataFlowBaseBuilderImageTag: "local/sonataflow-builder:1.0.0"
 sonataFlowDevModeImageTag: "local/sonataflow-devmode:1.0.0"
+postgreSQLPersistenceExtensions:
+  - groupId: "io.quarkus"
+    artifactId: quarkus-jdbc-postgresql
+    version: 3.2.10.Final
+  - groupId: io.quarkus
+    artifactId: quarkus-agroal
+    version: 3.2.10.Final
+  - groupId: org.kie
+    artifactId: kie-addons-quarkus-persistence-jdbc
+    version: 999-SNAPSHOT

--- a/controllers/platform/services/services.go
+++ b/controllers/platform/services/services.go
@@ -405,6 +405,7 @@ func (j JobServiceHandler) ConfigurePersistence(containerSpec *corev1.Container)
 		c.Env = append(c.Env, persistence.ConfigurePostgreSQLEnv(p.PostgreSQL, j.GetServiceName(), j.platform.Namespace)...)
 		// Specific to Job Service
 		c.Env = append(c.Env, corev1.EnvVar{Name: "QUARKUS_FLYWAY_MIGRATE_AT_START", Value: "true"})
+		c.Env = append(c.Env, corev1.EnvVar{Name: "KOGITO_JOBS_SERVICE_LOADJOBERRORSTRATEGY", Value: "FAIL_SERVICE"})
 		return c
 	}
 	return containerSpec

--- a/controllers/profiles/common/object_creators_test.go
+++ b/controllers/profiles/common/object_creators_test.go
@@ -295,14 +295,6 @@ func TestMergePodSpec_WithPostgreSQL_and_JDBC_URL_field(t *testing.T) {
 			Name:  "KOGITO_PERSISTENCE_TYPE",
 			Value: "jdbc",
 		},
-		{
-			Name:  "KOGITO_PERSISTENCE_PROTO_MARSHALLER",
-			Value: "false",
-		},
-		{
-			Name:  "KOGITO_PERSISTENCE_QUERY_TIMEOUT_MILLIS",
-			Value: "10000",
-		},
 	}
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 2)
 	assert.Equal(t, "superuser", deployment.Spec.Template.Spec.ServiceAccountName)
@@ -387,14 +379,6 @@ func TestMergePodSpec_OverrideContainers_WithPostgreSQL_In_Workflow_CR(t *testin
 			Name:  "KOGITO_PERSISTENCE_TYPE",
 			Value: "jdbc",
 		},
-		{
-			Name:  "KOGITO_PERSISTENCE_PROTO_MARSHALLER",
-			Value: "false",
-		},
-		{
-			Name:  "KOGITO_PERSISTENCE_QUERY_TIMEOUT_MILLIS",
-			Value: "10000",
-		},
 	}
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 	flowContainer, _ := kubeutil.GetContainerByName(v1alpha08.DefaultContainerName, &deployment.Spec.Template.Spec)
@@ -466,14 +450,6 @@ func TestMergePodSpec_WithServicedPostgreSQL_In_Platform_CR_And_Worflow_Requesti
 		{
 			Name:  "KOGITO_PERSISTENCE_TYPE",
 			Value: "jdbc",
-		},
-		{
-			Name:  "KOGITO_PERSISTENCE_PROTO_MARSHALLER",
-			Value: "false",
-		},
-		{
-			Name:  "KOGITO_PERSISTENCE_QUERY_TIMEOUT_MILLIS",
-			Value: "10000",
 		},
 	}
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
@@ -574,14 +550,6 @@ func TestMergePodSpec_WithServicedPostgreSQL_In_Platform_And_In_Workflow_CR(t *t
 		{
 			Name:  "KOGITO_PERSISTENCE_TYPE",
 			Value: "jdbc",
-		},
-		{
-			Name:  "KOGITO_PERSISTENCE_PROTO_MARSHALLER",
-			Value: "false",
-		},
-		{
-			Name:  "KOGITO_PERSISTENCE_QUERY_TIMEOUT_MILLIS",
-			Value: "10000",
 		},
 	}
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)

--- a/controllers/profiles/common/persistence/persistence.go
+++ b/controllers/profiles/common/persistence/persistence.go
@@ -12,13 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workflows
+package persistence
+
+import (
+	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+	"github.com/magiconair/properties"
+)
 
 const (
 	QuarkusFlywayMigrateAtStart         string = "quarkus.flyway.migrate-at-start"
+	QuarkusDatasourceDBKind             string = "quarkus.datasource.db-kind"
 	QuarkusDatasourceJDBCURL            string = "quarkus.datasource.jdbc.url"
 	KogitoPersistenceType               string = "kogito.persistence.type"
 	JDBCPersistenceType                 string = "jdbc"
 	KogitoPersistenceQueryTimeoutMillis string = "kogito.persistence.query.timeout.millis"
 	KogitoPersistenceProtoMarshaller    string = "kogito.persistence.proto.marshaller"
+	PostgreSQLDBKind                    string = "postgresql"
 )
+
+// ResolveWorkflowPersistenceProperties returns the set of application properties required for the workflow persistence.
+// Never nil.
+func ResolveWorkflowPersistenceProperties(workflow *operatorapi.SonataFlow, platform *operatorapi.SonataFlowPlatform) (*properties.Properties, error) {
+	if UsesPostgreSQLPersistence(workflow, platform) {
+		return GetPostgreSQLWorkflowProperties(workflow), nil
+	}
+	return properties.NewProperties(), nil
+}

--- a/controllers/profiles/common/persistence/persistence_test.go
+++ b/controllers/profiles/common/persistence/persistence_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Apache Software Foundation (ASF)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persistence
+
+import (
+	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestResolveWorkflowPersistenceProperties_WithWorkflowPersistence(t *testing.T) {
+	workflow := operatorapi.SonataFlow{
+		Spec: operatorapi.SonataFlowSpec{
+			Persistence: &operatorapi.PersistenceOptionsSpec{
+				PostgreSQL: &operatorapi.PersistencePostgreSQL{},
+			},
+		},
+	}
+	platform := operatorapi.SonataFlowPlatform{}
+	testResolveWorkflowPersistencePropertiesWithPersistence(t, &workflow, &platform)
+}
+
+func TestResolveWorkflowPersistenceProperties_WithPlatformPersistence(t *testing.T) {
+	workflow := operatorapi.SonataFlow{}
+	platform := operatorapi.SonataFlowPlatform{
+		Spec: operatorapi.SonataFlowPlatformSpec{
+			Persistence: &operatorapi.PlatformPersistenceOptionsSpec{
+				PostgreSQL: &operatorapi.PlatformPersistencePostgreSQL{},
+			},
+		},
+	}
+	testResolveWorkflowPersistencePropertiesWithPersistence(t, &workflow, &platform)
+}
+
+func TestResolveWorkflowPersistenceProperties_WithNoPersistence(t *testing.T) {
+	workflow := operatorapi.SonataFlow{}
+	platform := operatorapi.SonataFlowPlatform{}
+	props, err := ResolveWorkflowPersistenceProperties(&workflow, &platform)
+	assert.NotNil(t, props)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, props.Len())
+}
+
+func testResolveWorkflowPersistencePropertiesWithPersistence(t *testing.T, workflow *operatorapi.SonataFlow, platform *operatorapi.SonataFlowPlatform) {
+	props, err := ResolveWorkflowPersistenceProperties(workflow, platform)
+	assert.Nil(t, err)
+	assert.NotNil(t, props)
+	assert.Equal(t, 3, props.Len())
+	value, _ := props.Get("kogito.persistence.type")
+	assert.Equal(t, "jdbc", value)
+	value, _ = props.Get("quarkus.datasource.db-kind")
+	assert.Equal(t, "postgresql", value)
+	value, _ = props.Get("kogito.persistence.proto.marshaller")
+	assert.Equal(t, "false", value)
+}

--- a/controllers/profiles/common/persistence/persistence_test.go
+++ b/controllers/profiles/common/persistence/persistence_test.go
@@ -15,9 +15,10 @@
 package persistence
 
 import (
+	"testing"
+
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestResolveWorkflowPersistenceProperties_WithWorkflowPersistence(t *testing.T) {

--- a/controllers/profiles/common/persistence/persistence_test.go
+++ b/controllers/profiles/common/persistence/persistence_test.go
@@ -45,6 +45,22 @@ func TestResolveWorkflowPersistenceProperties_WithPlatformPersistence(t *testing
 	testResolveWorkflowPersistencePropertiesWithPersistence(t, &workflow, &platform)
 }
 
+func TestResolveWorkflowPersistenceProperties_WithPlatformPersistenceButBannedInWorkflow(t *testing.T) {
+	workflow := operatorapi.SonataFlow{}
+	workflow.Spec.Persistence = &operatorapi.PersistenceOptionsSpec{}
+	platform := operatorapi.SonataFlowPlatform{
+		Spec: operatorapi.SonataFlowPlatformSpec{
+			Persistence: &operatorapi.PlatformPersistenceOptionsSpec{
+				PostgreSQL: &operatorapi.PlatformPersistencePostgreSQL{},
+			},
+		},
+	}
+	props, err := ResolveWorkflowPersistenceProperties(&workflow, &platform)
+	assert.NotNil(t, props)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, props.Len())
+}
+
 func TestResolveWorkflowPersistenceProperties_WithNoPersistence(t *testing.T) {
 	workflow := operatorapi.SonataFlow{}
 	platform := operatorapi.SonataFlowPlatform{}

--- a/controllers/profiles/common/persistence/postgresql.go
+++ b/controllers/profiles/common/persistence/postgresql.go
@@ -131,7 +131,7 @@ func RetrieveConfiguration(primary *v1alpha08.PersistenceOptionsSpec, platformPe
 
 func UsesPostgreSQLPersistence(workflow *operatorapi.SonataFlow, platform *operatorapi.SonataFlowPlatform) bool {
 	return (workflow.Spec.Persistence != nil && workflow.Spec.Persistence.PostgreSQL != nil) ||
-		(platform.Spec.Persistence != nil && platform.Spec.Persistence.PostgreSQL != nil)
+		(workflow.Spec.Persistence == nil && platform.Spec.Persistence != nil && platform.Spec.Persistence.PostgreSQL != nil)
 }
 
 // GetPostgreSQLExtensions returns the Quarkus extensions required for postgresql persistence.

--- a/controllers/profiles/common/persistence/postgresql.go
+++ b/controllers/profiles/common/persistence/postgresql.go
@@ -17,17 +17,21 @@ package persistence
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/cfg"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/profiles"
+	"github.com/magiconair/properties"
 
 	"github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/profiles/common/constants"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	defaultDatabaseName = "sonataflow"
 )
 
+// ConfigurePostgreSQLEnv returns the common env variables required for the DataIndex or JobsService when postresql persistence is used.
 func ConfigurePostgreSQLEnv(postgresql *operatorapi.PersistencePostgreSQL, databaseSchema, databaseNamespace string) []corev1.EnvVar {
 	dataSourcePort := constants.DefaultPostgreSQLPort
 	databaseName := defaultDatabaseName
@@ -89,14 +93,6 @@ func ConfigurePostgreSQLEnv(postgresql *operatorapi.PersistencePostgreSQL, datab
 			Name:  "KOGITO_PERSISTENCE_TYPE",
 			Value: "jdbc",
 		},
-		{
-			Name:  "KOGITO_PERSISTENCE_PROTO_MARSHALLER",
-			Value: "false",
-		},
-		{
-			Name:  "KOGITO_PERSISTENCE_QUERY_TIMEOUT_MILLIS",
-			Value: "10000",
-		},
 	}
 }
 
@@ -131,4 +127,28 @@ func RetrieveConfiguration(primary *v1alpha08.PersistenceOptionsSpec, platformPe
 		}
 	}
 	return c
+}
+
+func UsesPostgreSQLPersistence(workflow *operatorapi.SonataFlow, platform *operatorapi.SonataFlowPlatform) bool {
+	return (workflow.Spec.Persistence != nil && workflow.Spec.Persistence.PostgreSQL != nil) ||
+		(platform.Spec.Persistence != nil && platform.Spec.Persistence.PostgreSQL != nil)
+}
+
+// GetPostgreSQLExtensions returns the Quarkus extensions required for postgresql persistence.
+func GetPostgreSQLExtensions() []cfg.GAV {
+	return cfg.GetCfg().PostgreSQLPersistenceExtensions
+}
+
+// GetPostgreSQLWorkflowProperties returns the set of application properties required for postgresql persistence.
+// Never nil.
+func GetPostgreSQLWorkflowProperties(workflow *operatorapi.SonataFlow) *properties.Properties {
+	props := properties.NewProperties()
+	if !profiles.IsDevProfile(workflow) && !profiles.IsGitOpsProfile(workflow) {
+		// build-time property required by kogito-runtimes to feed flyway build-time settings and package the necessary .sql files.
+		props.Set(QuarkusDatasourceDBKind, PostgreSQLDBKind)
+		// build-time properties for kogito-runtimes to use jdbc
+		props.Set(KogitoPersistenceType, JDBCPersistenceType)
+		props.Set(KogitoPersistenceProtoMarshaller, "false")
+	}
+	return props
 }

--- a/controllers/profiles/common/properties/managed.go
+++ b/controllers/profiles/common/properties/managed.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/profiles/common/persistence"
+
 	"github.com/apache/incubator-kie-kogito-serverless-operator/utils"
 
 	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/discovery"
@@ -149,6 +151,11 @@ func NewManagedPropertyHandler(workflow *operatorapi.SonataFlow, platform *opera
 	props.Set(constants.KogitoUserTasksEventsEnabled, "false")
 	if platform != nil {
 		p, err := resolvePlatformWorkflowProperties(platform)
+		if err != nil {
+			return nil, err
+		}
+		props.Merge(p)
+		p, err = persistence.ResolveWorkflowPersistenceProperties(workflow, platform)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/profiles/preview/profile_preview.go
+++ b/controllers/profiles/preview/profile_preview.go
@@ -102,7 +102,7 @@ func NewProfileReconciler(client client.Client, cfg *rest.Config, recorder recor
 	}
 	// the reconciliation state machine
 	stateMachine := common.NewReconciliationStateMachine(
-		&newBuilderState{StateSupport: support},
+		&newBuilderState{StateSupport: support, ensurers: NewObjectEnsurers(support)},
 		&followBuildStatusState{StateSupport: support},
 		&deployWithBuildWorkflowState{StateSupport: support, ensurers: NewObjectEnsurers(support)},
 	)

--- a/controllers/profiles/profile.go
+++ b/controllers/profiles/profile.go
@@ -76,3 +76,6 @@ type ReconciliationState interface {
 
 // IsDevProfile is an alias for workflowproj.IsDevProfile
 var IsDevProfile = workflowproj.IsDevProfile
+
+// IsGitOpsProfile is an alias for workflowproj.IsGitOpsProfile
+var IsGitOpsProfile = workflowproj.IsGitOpsProfile

--- a/controllers/profiles/profile_test.go
+++ b/controllers/profiles/profile_test.go
@@ -37,3 +37,17 @@ func Test_workflowIsDevProfile(t *testing.T) {
 	workflowWithProdProfile := test.GetBaseSonataFlowWithProdProfile(t.Name())
 	assert.False(t, IsDevProfile(workflowWithProdProfile))
 }
+
+func Test_workflowGitOpsProfile(t *testing.T) {
+	workflowWithDevProfile := test.GetBaseSonataFlowWithDevProfile(t.Name())
+	assert.False(t, IsGitOpsProfile(workflowWithDevProfile))
+
+	workflowWithNoProfile := test.GetBaseSonataFlow(t.Name())
+	assert.False(t, IsGitOpsProfile(workflowWithNoProfile))
+
+	workflowWithProdProfile := test.GetBaseSonataFlowWithProdProfile(t.Name())
+	assert.False(t, IsGitOpsProfile(workflowWithProdProfile))
+
+	workflowWithGitopsProfile := test.GetBaseSonataFlowWithGitopsProfile(t.Name())
+	assert.True(t, IsGitOpsProfile(workflowWithGitopsProfile))
+}

--- a/operator.yaml
+++ b/operator.yaml
@@ -27028,7 +27028,7 @@ data:
     # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
     # in cases where the workflow being built has configured postgresql persistence.
     postgreSQLPersistenceExtensions:
-      - groupId: "io.quarkus"
+      - groupId: io.quarkus
         artifactId: quarkus-jdbc-postgresql
         version: 3.2.10.Final
       - groupId: io.quarkus

--- a/operator.yaml
+++ b/operator.yaml
@@ -27025,6 +27025,18 @@ data:
     sonataFlowDevModeImageTag: ""
     # The default name of the builder configMap in the operator's namespace
     builderConfigMapName: "sonataflow-operator-builder-config"
+    # Quarkus extensions required for workflows persistence. These extensions are used by the SonataFlow build system,
+    # in cases where the workflow being built has configured postgresql persistence.
+    postgreSQLPersistenceExtensions:
+      - groupId: "io.quarkus"
+        artifactId: quarkus-jdbc-postgresql
+        version: 3.2.10.Final
+      - groupId: io.quarkus
+        artifactId: quarkus-agroal
+        version: 3.2.10.Final
+      - groupId: org.kie
+        artifactId: kie-addons-quarkus-persistence-jdbc
+        version: 999-SNAPSHOT
 kind: ConfigMap
 metadata:
   name: sonataflow-operator-controllers-config

--- a/test/cfg.go
+++ b/test/cfg.go
@@ -1,0 +1,30 @@
+// Copyright 2024 Apache Software Foundation (ASF)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/apache/incubator-kie-kogito-serverless-operator/controllers/cfg"
+	"github.com/stretchr/testify/assert"
+)
+
+// RestoreControllersConfig Utility function to restore the controllers global configuration in situations where
+// a particular test must populate it with values form a given file. As part of the given test finalization we can
+// invoke this function to restore the global configuration.
+func RestoreControllersConfig(t *testing.T) {
+	_, err := cfg.InitializeControllersCfgAt(getProjectDir() + "/config/manager/controllers_cfg.yaml")
+	assert.NoError(t, err)
+}

--- a/test/testdata/workflow/persistence/by_service/03-configmap_callbackstatetimeouts-props.yaml
+++ b/test/testdata/workflow/persistence/by_service/03-configmap_callbackstatetimeouts-props.yaml
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: sonataflow.org/v1alpha08
-kind: SonataFlowPlatform
+apiVersion: v1
+data:
+  application.properties: |
+    # set the flyway initialization in the WF ConfigMap
+    quarkus.flyway.migrate-at-start=true
+kind: ConfigMap
 metadata:
-  name: sonataflow-platform
-spec:
-  build:
-    config:
-      strategyOptions:
-        KanikoBuildCacheEnabled: "true"
+  labels:
+    app: callbackstatetimeouts
+  name: callbackstatetimeouts-props

--- a/test/testdata/workflow/persistence/by_service/04-sonataflow_callbackstatetimeouts.sw.yaml
+++ b/test/testdata/workflow/persistence/by_service/04-sonataflow_callbackstatetimeouts.sw.yaml
@@ -32,10 +32,6 @@ spec:
         databaseName: sonataflow
         databaseSchema: callbackstatetimeouts
   podTemplate:
-    container:
-      env:
-      - name: QUARKUS_FLYWAY_MIGRATE_AT_START
-        value: "true"
     initContainers:
       - name: init-postgres
         image: registry.access.redhat.com/ubi9/ubi-micro:latest

--- a/test/testdata/workflow/persistence/by_service/kustomization.yaml
+++ b/test/testdata/workflow/persistence/by_service/kustomization.yaml
@@ -15,7 +15,8 @@
 resources:
 - 01-postgres.yaml
 - 02-sonataflow_platform.yaml
-- 03-sonataflow_callbackstatetimeouts.sw.yaml
+- 03-configmap_callbackstatetimeouts-props.yaml
+- 04-sonataflow_callbackstatetimeouts.sw.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/test/testdata/workflow/persistence/from_platform_overwritten_by_service/02-sonataflow_platform.yaml
+++ b/test/testdata/workflow/persistence/from_platform_overwritten_by_service/02-sonataflow_platform.yaml
@@ -28,10 +28,6 @@ spec:
         port: 3456
         databaseName: db_name
   build:
-    template:
-      buildArgs:
-      - name: QUARKUS_EXTENSIONS
-        value: org.kie:kie-addons-quarkus-persistence-jdbc:999-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final
     config:
       strategyOptions:
         KanikoBuildCacheEnabled: "true"  

--- a/test/testdata/workflow/persistence/from_platform_overwritten_by_service/03-sonataflow_callbackstatetimeouts.sw.yaml
+++ b/test/testdata/workflow/persistence/from_platform_overwritten_by_service/03-sonataflow_callbackstatetimeouts.sw.yaml
@@ -34,6 +34,7 @@ spec:
   podTemplate:
     container:
       env:
+      # set the flyway initialization in the WF container env
       - name: QUARKUS_FLYWAY_MIGRATE_AT_START
         value: "true"
     initContainers:

--- a/test/testdata/workflow/persistence/from_platform_with_di_and_js_services/02-sonataflow_platform.yaml
+++ b/test/testdata/workflow/persistence/from_platform_with_di_and_js_services/02-sonataflow_platform.yaml
@@ -28,10 +28,6 @@ spec:
         port: 5432
         databaseName: sonataflow
   build:
-    template:
-      buildArgs:
-      - name: QUARKUS_EXTENSIONS
-        value: org.kie:kie-addons-quarkus-persistence-jdbc:999-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final
     config:
       strategyOptions:
         KanikoBuildCacheEnabled: "true"

--- a/test/testdata/workflow/persistence/from_platform_with_di_and_js_services/03-configmap_callbackstatetimeouts-props.yaml
+++ b/test/testdata/workflow/persistence/from_platform_with_di_and_js_services/03-configmap_callbackstatetimeouts-props.yaml
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: sonataflow.org/v1alpha08
-kind: SonataFlowPlatform
+apiVersion: v1
+data:
+  application.properties: |
+    # set the flyway initialization in the WF ConfigMap 
+    quarkus.flyway.migrate-at-start=true
+kind: ConfigMap
 metadata:
-  name: sonataflow-platform
-spec:
-  build:
-    config:
-      strategyOptions:
-        KanikoBuildCacheEnabled: "true"
+  labels:
+    app: callbackstatetimeouts
+  name: callbackstatetimeouts-props

--- a/test/testdata/workflow/persistence/from_platform_with_di_and_js_services/04-sonataflow_callbackstatetimeouts.sw.yaml
+++ b/test/testdata/workflow/persistence/from_platform_with_di_and_js_services/04-sonataflow_callbackstatetimeouts.sw.yaml
@@ -20,11 +20,6 @@ metadata:
     sonataflow.org/description: Callback State Timeouts Example k8s
     sonataflow.org/version: 0.0.1
 spec:
-  podTemplate:
-    container:
-      env:
-      - name: QUARKUS_FLYWAY_MIGRATE_AT_START
-        value: "true"
   flow:
     start: PrintStartMessage
     events:

--- a/test/testdata/workflow/persistence/from_platform_with_di_and_js_services/kustomization.yaml
+++ b/test/testdata/workflow/persistence/from_platform_with_di_and_js_services/kustomization.yaml
@@ -15,7 +15,8 @@
 resources:
 - 01-postgres.yaml
 - 02-sonataflow_platform.yaml
-- 03-sonataflow_callbackstatetimeouts.sw.yaml
+- 03-configmap_callbackstatetimeouts-props.yaml
+- 04-sonataflow_callbackstatetimeouts.sw.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/test/testdata/workflow/persistence/from_platform_with_no_persistence_required/02-sonataflow_platform.yaml
+++ b/test/testdata/workflow/persistence/from_platform_with_no_persistence_required/02-sonataflow_platform.yaml
@@ -28,10 +28,6 @@ spec:
         port: 5432
         databaseName: sonataflow
   build:
-    template:
-      buildArgs:
-      - name: QUARKUS_EXTENSIONS
-        value: org.kie:kie-addons-quarkus-persistence-jdbc:999-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final
     config:
       strategyOptions:
         KanikoBuildCacheEnabled: "true"

--- a/test/testdata/workflow/persistence/from_platform_without_di_and_js_services/02-sonataflow_platform.yaml
+++ b/test/testdata/workflow/persistence/from_platform_without_di_and_js_services/02-sonataflow_platform.yaml
@@ -28,10 +28,6 @@ spec:
         port: 5432
         databaseName: sonataflow
   build:
-    template:
-      buildArgs:
-      - name: QUARKUS_EXTENSIONS
-        value: org.kie:kie-addons-quarkus-persistence-jdbc:999-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final
     config:
       strategyOptions:
         KanikoBuildCacheEnabled: "true"  

--- a/test/testdata/workflow/persistence/from_platform_without_di_and_js_services/03-sonataflow_callbackstatetimeouts.sw.yaml
+++ b/test/testdata/workflow/persistence/from_platform_without_di_and_js_services/03-sonataflow_callbackstatetimeouts.sw.yaml
@@ -23,6 +23,7 @@ spec:
   podTemplate:
     container:
       env:
+      # set the flyway initialization in the WF container env
       - name: QUARKUS_FLYWAY_MIGRATE_AT_START
         value: "true"
   flow:

--- a/test/yaml.go
+++ b/test/yaml.go
@@ -199,6 +199,10 @@ func SetPreviewProfile(workflow *operatorapi.SonataFlow) {
 	workflow.Annotations["sonataflow.org/profile"] = "preview"
 }
 
+func SetGitopsProfile(workflow *operatorapi.SonataFlow) {
+	workflow.Annotations["sonataflow.org/profile"] = "gitops"
+}
+
 func GetBaseSonataFlow(namespace string) *operatorapi.SonataFlow {
 	return NewSonataFlow(sonataFlowSampleYamlCR, namespace)
 }
@@ -218,6 +222,10 @@ func GetBaseSonataFlowWithProdProfile(namespace string) *operatorapi.SonataFlow 
 // GetBaseSonataFlowWithPreviewProfile gets a base workflow that has a pre-built image set in podTemplate.
 func GetBaseSonataFlowWithPreviewProfile(namespace string) *operatorapi.SonataFlow {
 	return NewSonataFlow(SonataFlowSimpleOpsYamlCR, namespace)
+}
+
+func GetBaseSonataFlowWithGitopsProfile(namespace string) *operatorapi.SonataFlow {
+	return NewSonataFlow(sonataFlowSampleYamlCR, namespace, SetGitopsProfile)
 }
 
 func GetBaseClusterPlatformInReadyPhase(namespace string) *operatorapi.SonataFlowClusterPlatform {

--- a/workflowproj/operator.go
+++ b/workflowproj/operator.go
@@ -121,7 +121,7 @@ func CreateNewUserPropsConfigMap(workflow *operatorapi.SonataFlow) *corev1.Confi
 	}
 }
 
-// CreateNewManagedPropsConfigMap creates a new ConfigMap object to hold the managed application properties of the workflos.
+// CreateNewManagedPropsConfigMap creates a new ConfigMap object to hold the managed application properties of the workflows.
 func CreateNewManagedPropsConfigMap(workflow *operatorapi.SonataFlow, properties string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/workflowproj/workflowproj.go
+++ b/workflowproj/workflowproj.go
@@ -304,5 +304,18 @@ func (w *workflowProjectHandler) addResourceConfigMapToProject(cm *corev1.Config
 
 // IsDevProfile detects if the workflow is using the Dev profile or not
 func IsDevProfile(workflow *operatorapi.SonataFlow) bool {
-	return metadata.IsDevProfile(workflow.Annotations)
+	return isProfile(workflow, metadata.DevProfile)
+}
+
+// IsGitOpsProfile detects if the workflow is using the GitOps profile or not
+func IsGitOpsProfile(workflow *operatorapi.SonataFlow) bool {
+	return isProfile(workflow, metadata.GitOpsProfile)
+}
+
+func isProfile(workflow *operatorapi.SonataFlow, profileType metadata.ProfileType) bool {
+	profile := workflow.Annotations[metadata.Profile]
+	if len(profile) == 0 {
+		return false
+	}
+	return metadata.ProfileType(profile) == profileType
 }


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

Closes #441 