### PR TITLE
kie-kogito-serverless-operator-459: Update operator managed persistence extensions to quarkus 3.8.4

### DIFF
--- a/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
+++ b/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
@@ -34,10 +34,10 @@ data:
     postgreSQLPersistenceExtensions:
       - groupId: io.quarkus
         artifactId: quarkus-jdbc-postgresql
-        version: 3.2.10.Final
+        version: 3.8.4
       - groupId: io.quarkus
         artifactId: quarkus-agroal
-        version: 3.2.10.Final
+        version: 3.8.4
       - groupId: org.kie
         artifactId: kie-addons-quarkus-persistence-jdbc
         version: 999-SNAPSHOT

--- a/config/manager/controllers_cfg.yaml
+++ b/config/manager/controllers_cfg.yaml
@@ -31,10 +31,10 @@ builderConfigMapName: "sonataflow-operator-builder-config"
 postgreSQLPersistenceExtensions:
   - groupId: io.quarkus
     artifactId: quarkus-jdbc-postgresql
-    version: 3.2.10.Final
+    version: 3.8.4
   - groupId: io.quarkus
     artifactId: quarkus-agroal
-    version: 3.2.10.Final
+    version: 3.8.4
   - groupId: org.kie
     artifactId: kie-addons-quarkus-persistence-jdbc
     version: 999-SNAPSHOT

--- a/controllers/cfg/controllers_cfg_test.go
+++ b/controllers/cfg/controllers_cfg_test.go
@@ -37,13 +37,13 @@ func TestInitializeControllersCfgAt_ValidFile(t *testing.T) {
 	assert.Equal(t, GAV{
 		GroupId:    "io.quarkus",
 		ArtifactId: "quarkus-jdbc-postgresql",
-		Version:    "3.2.10.Final",
+		Version:    "3.8.4",
 	}, postgresExtensions[0])
 
 	assert.Equal(t, GAV{
 		GroupId:    "io.quarkus",
 		ArtifactId: "quarkus-agroal",
-		Version:    "3.2.10.Final",
+		Version:    "3.8.4",
 	}, postgresExtensions[1])
 
 	assert.Equal(t, GAV{

--- a/controllers/cfg/testdata/controllers-cfg-test.yaml
+++ b/controllers/cfg/testdata/controllers-cfg-test.yaml
@@ -24,10 +24,10 @@ sonataFlowDevModeImageTag: "local/sonataflow-devmode:1.0.0"
 postgreSQLPersistenceExtensions:
   - groupId: io.quarkus
     artifactId: quarkus-jdbc-postgresql
-    version: 3.2.10.Final
+    version: 3.8.4
   - groupId: io.quarkus
     artifactId: quarkus-agroal
-    version: 3.2.10.Final
+    version: 3.8.4
   - groupId: org.kie
     artifactId: kie-addons-quarkus-persistence-jdbc
     version: 999-SNAPSHOT

--- a/operator.yaml
+++ b/operator.yaml
@@ -27030,10 +27030,10 @@ data:
     postgreSQLPersistenceExtensions:
       - groupId: io.quarkus
         artifactId: quarkus-jdbc-postgresql
-        version: 3.2.10.Final
+        version: 3.8.4
       - groupId: io.quarkus
         artifactId: quarkus-agroal
-        version: 3.2.10.Final
+        version: 3.8.4
       - groupId: org.kie
         artifactId: kie-addons-quarkus-persistence-jdbc
         version: 999-SNAPSHOT


### PR DESCRIPTION
closes: #459 


Until this PR is not merged: https://github.com/apache/incubator-kie-tools/pull/2272/files the swf-builder nightly images are still in quarkus 3.2.10.Final, and for that reason the operator is using that version for the persistence extensions too.

After the merge, and when the nightly images are updated, we must move to 3.8.4

**NOTE:**  The e2e tests will fail until the new image with 3.8.4 is produced.


<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>