### PR TITLE
kie-issues#776: automate PR merge into protected branches

### DIFF
--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -80,14 +80,14 @@ pipeline {
             steps {
                 script {
                     dir(helper.getRepoName()) {
-                        helper.checkoutRepo()
 
                         // Merge PR
                         String prLink = properties.retrieve("${helper.getRepoName()}.pr.link")
-                        if (prLink) {
+                        if (prLink?.trim()) {
+                            githubscm.approvePR(prLink, helper.getGitAuthorCredsId())
                             githubscm.mergePR(prLink, helper.getGitAuthorPushCredsId())
-                            githubscm.pushObject('origin', helper.getBuildBranch(), helper.getGitAuthorPushCredsId())
                         }
+                        helper.checkoutRepo()
 
                         // Tag api / container-builder
                         helper.createTag("api/${helper.getGitTag()}")


### PR DESCRIPTION
Part of:
* apache/incubator-kie-issues#776

Other related PRs:
* apache/incubator-kie-kogito-pipelines#1194
* apache/incubator-kie-benchmarks#286
* apache/incubator-kie-docs#4536
* apache/incubator-kie-kogito-runtimes#3501
* apache/incubator-kie-kogito-apps#2047
* apache/incubator-kie-kogito-examples#1914
* apache/incubator-kie-kogito-docs#626
* apache/incubator-kie-drools#5927
* apache/incubator-kie-optaplanner#3083
* apache/incubator-kie-kogito-serverless-operator#462

Replacing old approach to merge PRs:  merge locally + push into remote

New behavior relies on gh cli directly to approve and merge PR.