### PR TITLE
Fix #486 - Set the controller config to the default platform

### DIFF
--- a/controllers/clusterplatform/clusterplatform.go
+++ b/controllers/clusterplatform/clusterplatform.go
@@ -25,9 +25,9 @@ import (
 	"github.com/apache/incubator-kie-kogito-serverless-operator/api/metadata"
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/log"
+	"github.com/apache/incubator-kie-kogito-serverless-operator/utils"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
-	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -35,15 +35,15 @@ const (
 )
 
 // GetActiveClusterPlatform returns the currently installed active cluster platform.
-func GetActiveClusterPlatform(ctx context.Context, c ctrl.Client) (*operatorapi.SonataFlowClusterPlatform, error) {
-	return getClusterPlatform(ctx, c, true)
+func GetActiveClusterPlatform(ctx context.Context) (*operatorapi.SonataFlowClusterPlatform, error) {
+	return getClusterPlatform(ctx, true)
 }
 
 // getClusterPlatform returns the currently active cluster platform or any cluster platform existing in the cluster.
-func getClusterPlatform(ctx context.Context, c ctrl.Client, active bool) (*operatorapi.SonataFlowClusterPlatform, error) {
+func getClusterPlatform(ctx context.Context, active bool) (*operatorapi.SonataFlowClusterPlatform, error) {
 	klog.V(log.D).InfoS("Finding available cluster platforms")
 
-	lst, err := listPrimaryClusterPlatforms(ctx, c)
+	lst, err := listPrimaryClusterPlatforms(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +66,8 @@ func getClusterPlatform(ctx context.Context, c ctrl.Client, active bool) (*opera
 }
 
 // listPrimaryClusterPlatforms returns all non-secondary cluster platforms installed (only one will be active).
-func listPrimaryClusterPlatforms(ctx context.Context, c ctrl.Reader) (*operatorapi.SonataFlowClusterPlatformList, error) {
-	lst, err := listAllClusterPlatforms(ctx, c)
+func listPrimaryClusterPlatforms(ctx context.Context) (*operatorapi.SonataFlowClusterPlatformList, error) {
+	lst, err := listAllClusterPlatforms(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func listPrimaryClusterPlatforms(ctx context.Context, c ctrl.Reader) (*operatora
 }
 
 // allDuplicatedClusterPlatforms returns true if every cluster platform has a "Duplicated" status set
-func allDuplicatedClusterPlatforms(ctx context.Context, c ctrl.Reader) bool {
-	lst, err := listAllClusterPlatforms(ctx, c)
+func allDuplicatedClusterPlatforms(ctx context.Context) bool {
+	lst, err := listAllClusterPlatforms(ctx)
 	if err != nil {
 		return false
 	}
@@ -99,9 +99,9 @@ func allDuplicatedClusterPlatforms(ctx context.Context, c ctrl.Reader) bool {
 }
 
 // listAllClusterPlatforms returns all clusterplatforms installed.
-func listAllClusterPlatforms(ctx context.Context, c ctrl.Reader) (*operatorapi.SonataFlowClusterPlatformList, error) {
+func listAllClusterPlatforms(ctx context.Context) (*operatorapi.SonataFlowClusterPlatformList, error) {
 	lst := operatorapi.NewSonataFlowClusterPlatformList()
-	if err := c.List(ctx, &lst); err != nil {
+	if err := utils.GetClient().List(ctx, &lst); err != nil {
 		return nil, err
 	}
 	return &lst, nil

--- a/controllers/clusterplatform/initialize.go
+++ b/controllers/clusterplatform/initialize.go
@@ -46,7 +46,7 @@ func (action *initializeAction) Name() string {
 }
 
 func (action *initializeAction) CanHandle(ctx context.Context, cPlatform *operatorapi.SonataFlowClusterPlatform) bool {
-	return !cPlatform.Status.IsDuplicated() || allDuplicatedClusterPlatforms(ctx, action.client)
+	return !cPlatform.Status.IsDuplicated() || allDuplicatedClusterPlatforms(ctx)
 }
 
 func (action *initializeAction) Handle(ctx context.Context, cPlatform *operatorapi.SonataFlowClusterPlatform) error {
@@ -107,7 +107,7 @@ func (action *initializeAction) isPrimaryDuplicate(ctx context.Context, cPlatfor
 		// Always reconcile secondary cluster platforms
 		return false, nil
 	}
-	platforms, err := listPrimaryClusterPlatforms(ctx, action.client)
+	platforms, err := listPrimaryClusterPlatforms(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/controllers/platform/initialize.go
+++ b/controllers/platform/initialize.go
@@ -77,7 +77,7 @@ func (action *initializeAction) Handle(ctx context.Context, platform *operatorap
 		return nil, nil
 	}
 
-	if err = ConfigureDefaults(ctx, action.client, platform, true); err != nil {
+	if err = CreateOrUpdateWithDefaults(ctx, platform, true); err != nil {
 		return nil, err
 	}
 	// nolint: staticcheck

--- a/controllers/platform/k8s.go
+++ b/controllers/platform/k8s.go
@@ -57,7 +57,7 @@ func (action *serviceAction) CanHandle(platform *operatorapi.SonataFlowPlatform)
 
 func (action *serviceAction) Handle(ctx context.Context, platform *operatorapi.SonataFlowPlatform) (*operatorapi.SonataFlowPlatform, error) {
 	// Refresh applied configuration
-	if err := ConfigureDefaults(ctx, action.client, platform, false); err != nil {
+	if err := CreateOrUpdateWithDefaults(ctx, platform, false); err != nil {
 		return nil, err
 	}
 

--- a/controllers/platform/monitor.go
+++ b/controllers/platform/monitor.go
@@ -54,7 +54,7 @@ func (action *monitorAction) Handle(ctx context.Context, platform *operatorapi.S
 	}
 
 	// Refresh applied configuration
-	if err := ConfigureDefaults(ctx, action.client, platform, false); err != nil {
+	if err := CreateOrUpdateWithDefaults(ctx, platform, false); err != nil {
 		return nil, err
 	}
 

--- a/controllers/profiles/common/properties/platform_test.go
+++ b/controllers/profiles/common/properties/platform_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/test"
-	"github.com/apache/incubator-kie-kogito-serverless-operator/utils"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,8 +63,7 @@ func Test_resolvePlatformWorkflowProperties(t *testing.T) {
 		},
 	}
 
-	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(platform, secret, cm).WithStatusSubresource(platform).Build()
-	utils.SetClient(client)
+	_ = test.NewSonataFlowClientBuilder().WithRuntimeObjects(platform, secret, cm).WithStatusSubresource(platform).Build()
 
 	props, err := resolvePlatformWorkflowProperties(platform)
 	assert.NoError(t, err)
@@ -106,8 +104,7 @@ func Test_resolvePlatformWorkflowProperties_RefNotFound(t *testing.T) {
 		},
 	}
 
-	client := test.NewSonataFlowClientBuilder().WithRuntimeObjects(platform).WithStatusSubresource(platform).Build()
-	utils.SetClient(client)
+	_ = test.NewSonataFlowClientBuilder().WithRuntimeObjects(platform).WithStatusSubresource(platform).Build()
 
 	props, err := resolvePlatformWorkflowProperties(platform)
 	assert.NoError(t, err)

--- a/controllers/sonataflowclusterplatform_controller.go
+++ b/controllers/sonataflowclusterplatform_controller.go
@@ -134,7 +134,7 @@ func (r *SonataFlowClusterPlatformReconciler) SetupWithManager(mgr ctrlrun.Manag
 
 // if actively referenced sonataflowplatform object is changed, reconcile the active SonataFlowClusterPlatform.
 func (r *SonataFlowClusterPlatformReconciler) mapPlatformToClusterPlatformRequests(ctx context.Context, object client.Object) []reconcile.Request {
-	sfcPlatform, err := clusterplatform.GetActiveClusterPlatform(ctx, r.Client)
+	sfcPlatform, err := clusterplatform.GetActiveClusterPlatform(ctx)
 	if err != nil && !errors.IsNotFound(err) {
 		klog.V(log.E).ErrorS(err, "Failed to get active SonataFlowClusterPlatform")
 		return nil

--- a/controllers/sonataflowplatform_controller.go
+++ b/controllers/sonataflowplatform_controller.go
@@ -114,7 +114,7 @@ func (r *SonataFlowPlatformReconciler) Reconcile(ctx context.Context, req reconc
 
 	target := instance.DeepCopy()
 
-	if err = r.SonataFlowPlatformUpdateStatus(ctx, req, target); err != nil {
+	if err = r.updateSonataFlowPlatformStatus(ctx, req, target); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -170,10 +170,10 @@ func (r *SonataFlowPlatformReconciler) Reconcile(ctx context.Context, req reconc
 
 }
 
-// If an active cluster platform exists, update platform.Status accordingly
-func (r *SonataFlowPlatformReconciler) SonataFlowPlatformUpdateStatus(ctx context.Context, req reconcile.Request, target *operatorapi.SonataFlowPlatform) error {
+// sonataFlowPlatformUpdateStatus If an active cluster platform exists, update platform.Status accordingly
+func (r *SonataFlowPlatformReconciler) updateSonataFlowPlatformStatus(ctx context.Context, req reconcile.Request, target *operatorapi.SonataFlowPlatform) error {
 	// Fetch the active SonataFlowClusterPlatform instance
-	sfcPlatform, err := clusterplatform.GetActiveClusterPlatform(ctx, r.Client)
+	sfcPlatform, err := clusterplatform.GetActiveClusterPlatform(ctx)
 	if err != nil && !errors.IsNotFound(err) {
 		klog.V(log.E).ErrorS(err, "Failed to get active SonataFlowClusterPlatform")
 		return err
@@ -241,7 +241,7 @@ func (r *SonataFlowPlatformReconciler) mapClusterPlatformToPlatformRequests(ctx 
 // if actively referenced sonataflowplatform is changed, reconcile other SonataFlowPlatforms in the cluster.
 func (r *SonataFlowPlatformReconciler) mapPlatformToPlatformRequests(ctx context.Context, object client.Object) []reconcile.Request {
 	platform := object.(*operatorapi.SonataFlowPlatform)
-	sfcPlatform, err := clusterplatform.GetActiveClusterPlatform(ctx, r.Client)
+	sfcPlatform, err := clusterplatform.GetActiveClusterPlatform(ctx)
 	if err != nil && !errors.IsNotFound(err) {
 		klog.V(log.E).ErrorS(err, "Failed to get active SonataFlowClusterPlatform")
 		return nil


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
The default `SonataFlowPlatform` created by the operator when the user does not, was missing the default configuration.

**Motivation for the change:**
Fix #486

**Checklist**

- [x] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>