### PR TITLE
:suspect: Fix resources display name

### DIFF
--- a/api/v1alpha08/sonataflow_types.go
+++ b/api/v1alpha08/sonataflow_types.go
@@ -255,6 +255,7 @@ func (s *SonataFlowStatus) IsBuildFailed() bool {
 // +operator-sdk:csv:customresourcedefinitions:resources={{Service,v1,"A Service for the Flow"}}
 // +operator-sdk:csv:customresourcedefinitions:resources={{Route,route.openshift.io/v1,"An OpenShift Route for the Flow"}}
 // +operator-sdk:csv:customresourcedefinitions:resources={{ConfigMap,v1,"The ConfigMaps with Flow definition and additional configuration files"}}
+// +operator-sdk:csv:customresourcedefinitions:displayName="SonataFlow"
 type SonataFlow struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha08/sonataflowbuild_types.go
+++ b/api/v1alpha08/sonataflowbuild_types.go
@@ -145,6 +145,7 @@ func (k *SonataFlowBuildStatus) GetInnerBuild(innerBuild interface{}) error {
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.buildPhase`
 // +kubebuilder:resource:shortName={"sfb", "sfbuild", "sfbuilds"}
 // +operator-sdk:csv:customresourcedefinitions:resources={{BuildConfig,build.openshift.io/v1,"An Openshift Build Config"}}
+// +operator-sdk:csv:customresourcedefinitions:displayName="SonataFlowBuild"
 type SonataFlowBuild struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha08/sonataflowclusterplatform_types.go
+++ b/api/v1alpha08/sonataflowclusterplatform_types.go
@@ -93,6 +93,7 @@ func (in *SonataFlowClusterPlatformStatus) IsDuplicated() bool {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Succeed')].status`
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=='Succeed')].reason`
 // +operator-sdk:csv:customresourcedefinitions:resources={{SonataFlowPlatform,sonataflow.org/v1alpha08,"A SonataFlow Platform"}}
+// +operator-sdk:csv:customresourcedefinitions:displayName="SonataFlowClusterPlatform"
 type SonataFlowClusterPlatform struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha08/sonataflowplatform_types.go
+++ b/api/v1alpha08/sonataflowplatform_types.go
@@ -170,6 +170,7 @@ func (in *SonataFlowPlatformStatus) IsFailure() bool {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Succeed')].status`
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=='Succeed')].reason`
 // +operator-sdk:csv:customresourcedefinitions:resources={{Namespace,v1,"The Namespace controlled by the platform"}}
+// +operator-sdk:csv:customresourcedefinitions:displayName="SonataFlowPlatform"
 type SonataFlowPlatform struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sonataflow-operator.clusterserviceversion.yaml
@@ -135,7 +135,7 @@ spec:
     owned:
     - description: SonataFlowBuild is an internal custom resource to control workflow
         build instances in the target platform
-      displayName: Sonata Flow Build
+      displayName: SonataFlowBuild
       kind: SonataFlowBuild
       name: sonataflowbuilds.sonataflow.org
       resources:
@@ -182,7 +182,7 @@ spec:
       version: v1alpha08
     - description: SonataFlowClusterPlatform is the Schema for the sonataflowclusterplatforms
         API
-      displayName: Sonata Flow Cluster Platform
+      displayName: SonataFlowClusterPlatform
       kind: SonataFlowClusterPlatform
       name: sonataflowclusterplatforms.sonataflow.org
       resources:
@@ -211,7 +211,7 @@ spec:
       version: v1alpha08
     - description: SonataFlowPlatform is the descriptor for the workflow platform
         infrastructure.
-      displayName: Sonata Flow Platform
+      displayName: SonataFlowPlatform
       kind: SonataFlowPlatform
       name: sonataflowplatforms.sonataflow.org
       resources:
@@ -281,7 +281,7 @@ spec:
       version: v1alpha08
     - description: SonataFlow is the descriptor representation for a workflow application
         based on the CNCF Serverless Workflow specification.
-      displayName: Sonata Flow
+      displayName: SonataFlow
       kind: SonataFlow
       name: sonataflows.sonataflow.org
       resources:

--- a/config/manifests/bases/sonataflow-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sonataflow-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ spec:
     owned:
     - description: SonataFlowBuild is an internal custom resource to control workflow
         build instances in the target platform
-      displayName: Sonata Flow Build
+      displayName: SonataFlowBuild
       kind: SonataFlowBuild
       name: sonataflowbuilds.sonataflow.org
       resources:
@@ -66,7 +66,7 @@ spec:
       version: v1alpha08
     - description: SonataFlowClusterPlatform is the Schema for the sonataflowclusterplatforms
         API
-      displayName: Sonata Flow Cluster Platform
+      displayName: SonataFlowClusterPlatform
       kind: SonataFlowClusterPlatform
       name: sonataflowclusterplatforms.sonataflow.org
       resources:
@@ -95,7 +95,7 @@ spec:
       version: v1alpha08
     - description: SonataFlowPlatform is the descriptor for the workflow platform
         infrastructure.
-      displayName: Sonata Flow Platform
+      displayName: SonataFlowPlatform
       kind: SonataFlowPlatform
       name: sonataflowplatforms.sonataflow.org
       resources:
@@ -165,7 +165,7 @@ spec:
       version: v1alpha08
     - description: SonataFlow is the descriptor representation for a workflow application
         based on the CNCF Serverless Workflow specification.
-      displayName: Sonata Flow
+      displayName: SonataFlow
       kind: SonataFlow
       name: sonataflows.sonataflow.org
       resources:


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
Quick one to fix the `displayName` of our objects.

**Motivation for the change:**
The `displayName` is used in multiple platforms to refer to our CRDs.

**Checklist**

- [ ] Add or Modify a unit test for your change
- [x] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>