### PR TITLE
NO-ISSUE: Fix image registry credentials helper methods

### DIFF
--- a/.ci/jenkins/scripts/helper.groovy
+++ b/.ci/jenkins/scripts/helper.groovy
@@ -127,11 +127,11 @@ boolean isImageInOpenshiftRegistry(String paramsPrefix = defaultImageParamsPrefi
 }
 
 String getImageRegistryUserCredentialsId(String paramsPrefix = defaultImageParamsPrefix) {
-    return params[constructKey(paramsPrefix, 'IMAGE_REGISTRY_USER_CREDENTIALS_ID')]
+    return params[constructKey(paramsPrefix, 'REGISTRY_USER_CREDENTIALS_ID')]
 }
 
 String getImageRegistryTokenCredentialsId(String paramsPrefix = defaultImageParamsPrefix) {
-    return params[constructKey(paramsPrefix, 'IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID')]
+    return params[constructKey(paramsPrefix, 'REGISTRY_TOKEN_CREDENTIALS_ID')]
 }
 
 String getImageRegistryCredentials(String paramsPrefix = defaultImageParamsPrefix) {


### PR DESCRIPTION
This PR fixes the `getImageRegistryUserCredentialsId` and the `getImageRegistryTokenCredentialsId` helper methods used in the CI jobs by removing the `IMAGE_` prefix as they are defined in each job according to their types.