### PR TITLE
NO-ISSUE: Fix image names in CI and the script to bump versions

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -92,7 +92,7 @@ void setupDeployJob(JobType jobType) {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        OPERATOR_IMAGE_NAME: 'kogito-serverless-operator',
+        OPERATOR_IMAGE_NAME: 'incubator-kie-sonataflow-operator',
         MAX_REGISTRY_RETRIES: 3,
         OPENSHIFT_API_KEY: 'OPENSHIFT_API',
         OPENSHIFT_CREDS_KEY: 'OPENSHIFT_CREDS',
@@ -190,7 +190,7 @@ void setupE2EJob(JobType jobType, String clusterName, Map extraEnv = [:]) {
 
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
 
-        OPERATOR_IMAGE_NAME: 'kogito-serverless-operator',
+        OPERATOR_IMAGE_NAME: 'incubator-kie-sonataflow-operator,
         MAX_REGISTRY_RETRIES: 3,
         PROPERTIES_FILE_NAME: 'deployment.properties',
     ])
@@ -214,7 +214,7 @@ void setupWeeklyDeployJob(JobType jobType) {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        OPERATOR_IMAGE_NAME: 'kogito-serverless-operator',
+        OPERATOR_IMAGE_NAME: 'incubator-kie-sonataflow-operator',
         MAX_REGISTRY_RETRIES: 3,
         PROPERTIES_FILE_NAME: 'deployment.properties',
 

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -190,7 +190,7 @@ void setupE2EJob(JobType jobType, String clusterName, Map extraEnv = [:]) {
 
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
 
-        OPERATOR_IMAGE_NAME: 'incubator-kie-sonataflow-operator,
+        OPERATOR_IMAGE_NAME: 'incubator-kie-sonataflow-operator',
         MAX_REGISTRY_RETRIES: 3,
         PROPERTIES_FILE_NAME: 'deployment.properties',
     ])

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -35,7 +35,7 @@ newMajorMinorVersion=${new_version%.*}
 
 echo "Set new version to ${new_version} (majorMinor = ${newMajorMinorVersion})"
 
-sed -i "s|version: ${old_version}|version: ${new_version}|g" image.yaml
+sed -i "s|version: ${old_version}|version: ${new_version}|g" images/manager.yaml
 
 sed -i "s|^VERSION ?=.*|VERSION ?= ${new_version}|g" Makefile
 sed -i "s|^REDUCED_VERSION ?=.*|REDUCED_VERSION ?= ${newMajorMinorVersion}|g" Makefile
@@ -45,12 +45,6 @@ sed -i "s|IMAGE_TAG_BASE ?=.*|IMAGE_TAG_BASE ?= ${imageTag}|g" Makefile
 sed -i "s|newName:.*|newName: ${imageTag}|g" config/manager/kustomization.yaml
 
 # Update sonataflow-* images
-find . -name "*.yaml" -exec sed -i "s|docker.io/apache/incubator-kie-sonataflow-builder.*:${oldMajorMinorVersion}|docker.io/apache/incubator-kie-sonataflow-builder:${newMajorMinorVersion}|" {} +
-sed -i "s|docker.io/apache/incubator-kie-sonataflow-builder.*:${oldMajorMinorVersion}|docker.io/apache/incubator-kie-sonataflow-builder:${newMajorMinorVersion}|" Dockerfile
-
-find . -name "*.yaml" -exec sed -i "s|docker.io/apache/incubator-kie-sonataflow-devmode.*:${oldMajorMinorVersion}|docker.io/apache/incubator-kie-sonataflow-devmode:${newMajorMinorVersion}|" {} +
-sed -i "s|docker.io/apache/incubator-kie-sonataflow-devmode.*:${oldMajorMinorVersion}|docker.io/apache/incubator-kie-sonataflow-devmode:${newMajorMinorVersion}|" Dockerfile
-
 sed -i -r "s|operatorVersion =.*|operatorVersion = \"${new_version}\"|g" version/version.go
 
 sed -i "s|containerImage:.*|containerImage: ${imageTag}:${newMajorMinorVersion}|g" $(getCsvFile)

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -44,7 +44,6 @@ sed -i "s|newTag:.*|newTag: ${new_version}|g" config/manager/kustomization.yaml
 sed -i "s|IMAGE_TAG_BASE ?=.*|IMAGE_TAG_BASE ?= ${imageTag}|g" Makefile
 sed -i "s|newName:.*|newName: ${imageTag}|g" config/manager/kustomization.yaml
 
-# Update sonataflow-* images
 sed -i -r "s|operatorVersion =.*|operatorVersion = \"${new_version}\"|g" version/version.go
 
 sed -i "s|containerImage:.*|containerImage: ${imageTag}:${newMajorMinorVersion}|g" $(getCsvFile)


### PR DESCRIPTION
Fixes image names on CI after the migration to dockerhub and also fixes the script to bump the project version.