### PR TITLE
Make migrateDBOnStartUp property optional

### DIFF
--- a/api/v1alpha08/sonataflow_persistence_types.go
+++ b/api/v1alpha08/sonataflow_persistence_types.go
@@ -52,6 +52,8 @@ type PersistenceOptionsSpec struct {
 	PostgreSQL *PersistencePostgreSQL `json:"postgresql,omitempty"`
 
 	// Whether to migrate database on service startup?
+	// +optional
+	// +default: false
 	MigrateDBOnStartUp bool `json:"migrateDBOnStartUp"`
 }
 

--- a/bundle/manifests/sonataflow.org_sonataflowplatforms.yaml
+++ b/bundle/manifests/sonataflow.org_sonataflowplatforms.yaml
@@ -628,8 +628,6 @@ spec:
                             required:
                             - secretRef
                             type: object
-                        required:
-                        - migrateDBOnStartUp
                         type: object
                       podTemplate:
                         description: PodTemplate describes the deployment details
@@ -8505,8 +8503,6 @@ spec:
                             required:
                             - secretRef
                             type: object
-                        required:
-                        - migrateDBOnStartUp
                         type: object
                       podTemplate:
                         description: PodTemplate describes the deployment details

--- a/bundle/manifests/sonataflow.org_sonataflows.yaml
+++ b/bundle/manifests/sonataflow.org_sonataflows.yaml
@@ -2163,8 +2163,6 @@ spec:
                     required:
                     - secretRef
                     type: object
-                required:
-                - migrateDBOnStartUp
                 type: object
               podTemplate:
                 description: PodTemplate describes the deployment details of this

--- a/config/crd/bases/sonataflow.org_sonataflowplatforms.yaml
+++ b/config/crd/bases/sonataflow.org_sonataflowplatforms.yaml
@@ -629,8 +629,6 @@ spec:
                             required:
                             - secretRef
                             type: object
-                        required:
-                        - migrateDBOnStartUp
                         type: object
                       podTemplate:
                         description: PodTemplate describes the deployment details
@@ -8506,8 +8504,6 @@ spec:
                             required:
                             - secretRef
                             type: object
-                        required:
-                        - migrateDBOnStartUp
                         type: object
                       podTemplate:
                         description: PodTemplate describes the deployment details

--- a/config/crd/bases/sonataflow.org_sonataflows.yaml
+++ b/config/crd/bases/sonataflow.org_sonataflows.yaml
@@ -2164,8 +2164,6 @@ spec:
                     required:
                     - secretRef
                     type: object
-                required:
-                - migrateDBOnStartUp
                 type: object
               podTemplate:
                 description: PodTemplate describes the deployment details of this

--- a/controllers/sonataflowplatform_controller_test.go
+++ b/controllers/sonataflowplatform_controller_test.go
@@ -261,14 +261,10 @@ func TestSonataFlowPlatformController(t *testing.T) {
 		ksp.Spec = v1alpha08.SonataFlowPlatformSpec{
 			Services: &v1alpha08.ServicesPlatformSpec{
 				DataIndex: &v1alpha08.ServiceSpec{
-					Persistence: &v1alpha08.PersistenceOptionsSpec{
-						MigrateDBOnStartUp: false,
-					},
+					Persistence: &v1alpha08.PersistenceOptionsSpec{},
 				},
 				JobService: &v1alpha08.ServiceSpec{
-					Persistence: &v1alpha08.PersistenceOptionsSpec{
-						MigrateDBOnStartUp: false,
-					},
+					Persistence: &v1alpha08.PersistenceOptionsSpec{},
 				},
 			},
 			Persistence: &v1alpha08.PlatformPersistenceOptionsSpec{

--- a/operator.yaml
+++ b/operator.yaml
@@ -1120,8 +1120,6 @@ spec:
                             required:
                             - secretRef
                             type: object
-                        required:
-                        - migrateDBOnStartUp
                         type: object
                       podTemplate:
                         description: PodTemplate describes the deployment details
@@ -8997,8 +8995,6 @@ spec:
                             required:
                             - secretRef
                             type: object
-                        required:
-                        - migrateDBOnStartUp
                         type: object
                       podTemplate:
                         description: PodTemplate describes the deployment details
@@ -19070,8 +19066,6 @@ spec:
                     required:
                     - secretRef
                     type: object
-                required:
-                - migrateDBOnStartUp
                 type: object
               podTemplate:
                 description: PodTemplate describes the deployment details of this

--- a/test/testdata/workflow/persistence/by_service/04-sonataflow_callbackstatetimeouts.sw.yaml
+++ b/test/testdata/workflow/persistence/by_service/04-sonataflow_callbackstatetimeouts.sw.yaml
@@ -21,7 +21,6 @@ metadata:
     sonataflow.org/version: 0.0.1
 spec:
   persistence:
-    migrateDBOnStartUp: false
     postgresql:
       secretRef:
         name: postgres-secrets

--- a/test/testdata/workflow/persistence/from_platform_overwritten_by_service/03-sonataflow_callbackstatetimeouts.sw.yaml
+++ b/test/testdata/workflow/persistence/from_platform_overwritten_by_service/03-sonataflow_callbackstatetimeouts.sw.yaml
@@ -21,7 +21,6 @@ metadata:
     sonataflow.org/version: 0.0.1
 spec:
   persistence:
-    migrateDBOnStartUp: false
     postgresql:
       secretRef:
         name: postgres-secrets


### PR DESCRIPTION
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**
Fix for #524 : Make migrateDBOnStartUp optional to avoid deployment errors 


**Motivation for the change:**


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>