### PR TITLE
kie-kogito-serverless-operator-528: Disable partial DB Migrator work

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -31,7 +31,7 @@ const (
 	// When released, this version should reflect the `major.minor` version in the registry.
 	// For example, docker.io/apache/incubator-kie-sonataflow-operator:10.0
 	tagVersion        = "main"
-	serviceTagVersion = "weekly-latest"
+	serviceTagVersion = "main"
 )
 
 // GetOperatorVersion gets the current binary version of the operator. Do not use it to compose image tags!
@@ -45,8 +45,8 @@ func GetTagVersion() string {
 }
 
 // GetServiceTagVersion gets the current tag version for the service images.
-// TODO, unify all with tagVersion="main", when "main" tag is produced for DI and JS.
-// Right now, Apache community only produces "weekly-latest", and "timestamped tags" for these services.
+// TODO, double check Apache community continues producing JS and DI "main" tag images.
+// The "weekly-latest" tags are no longer produced.
 func GetServiceTagVersion() string {
 	return serviceTagVersion
 }


### PR DESCRIPTION
Closes: #528 
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>