### PR TITLE
kie-kogito-serverless-operator-548: Make the operator configure the kogito events grouping by default in preview and gitops workflow deployments

### DIFF
--- a/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
+++ b/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  controllers_cfg.yaml: |
+  controllers_cfg.yaml: |-
     # Licensed to the Apache Software Foundation (ASF) under one
     # or more contributor license agreements.  See the NOTICE file
     # distributed with this work for additional information
@@ -58,6 +58,9 @@ data:
       - groupId: org.kie
         artifactId: kie-addons-quarkus-persistence-jdbc
         version: 999-20240912-SNAPSHOT
+    # If true, the workflow deployments will be configured to send accumulated workflow status change events to the Data
+    # Index Service reducing the number of produced events. Set to false to send individual events.
+    kogitoEventsGrouping: true
 kind: ConfigMap
 metadata:
   name: sonataflow-operator-controllers-config

--- a/config/manager/controllers_cfg.yaml
+++ b/config/manager/controllers_cfg.yaml
@@ -55,3 +55,6 @@ postgreSQLPersistenceExtensions:
   - groupId: org.kie
     artifactId: kie-addons-quarkus-persistence-jdbc
     version: 999-20240912-SNAPSHOT
+# If true, the workflow deployments will be configured to send accumulated workflow status change events to the Data
+# Index Service reducing the number of produced events. Set to false to send individual events.
+kogitoEventsGrouping: true

--- a/internal/controller/cfg/controllers_cfg.go
+++ b/internal/controller/cfg/controllers_cfg.go
@@ -71,6 +71,7 @@ type ControllersCfg struct {
 	SonataFlowDevModeImageTag       string `yaml:"sonataFlowDevModeImageTag,omitempty"`
 	BuilderConfigMapName            string `yaml:"builderConfigMapName,omitempty"`
 	PostgreSQLPersistenceExtensions []GAV  `yaml:"postgreSQLPersistenceExtensions,omitempty"`
+	KogitoEventsGrouping            bool   `yaml:"kogitoEventsGrouping,omitempty"`
 }
 
 // InitializeControllersCfg initializes the platform configuration for this instance.

--- a/internal/controller/cfg/controllers_cfg_test.go
+++ b/internal/controller/cfg/controllers_cfg_test.go
@@ -54,6 +54,7 @@ func TestInitializeControllersCfgAt_ValidFile(t *testing.T) {
 		ArtifactId: "kie-addons-quarkus-persistence-jdbc",
 		Version:    "999-SNAPSHOT",
 	}, postgresExtensions[2])
+	assert.True(t, cfg.KogitoEventsGrouping)
 }
 
 func TestInitializeControllersCfgAt_FileNotFound(t *testing.T) {

--- a/internal/controller/cfg/testdata/controllers-cfg-test.yaml
+++ b/internal/controller/cfg/testdata/controllers-cfg-test.yaml
@@ -35,3 +35,4 @@ postgreSQLPersistenceExtensions:
   - groupId: org.kie
     artifactId: kie-addons-quarkus-persistence-jdbc
     version: 999-SNAPSHOT
+kogitoEventsGrouping: true

--- a/internal/controller/platform/services/services.go
+++ b/internal/controller/platform/services/services.go
@@ -603,6 +603,7 @@ func (d *DataIndexHandler) GenerateKnativeResources(platform *operatorapi.Sonata
 		d.newTrigger(lbl, brokerName, namespace, serviceName, "process-state", "ProcessInstanceStateDataEvent", constants.KogitoProcessInstancesEventsPath, platform),
 		d.newTrigger(lbl, brokerName, namespace, serviceName, "process-variable", "ProcessInstanceVariableDataEvent", constants.KogitoProcessInstancesEventsPath, platform),
 		d.newTrigger(lbl, brokerName, namespace, serviceName, "process-definition", "ProcessDefinitionEvent", constants.KogitoProcessDefinitionsEventsPath, platform),
+		d.newTrigger(lbl, brokerName, namespace, serviceName, "process-instance-multiple", "MultipleProcessInstanceDataEvent", constants.KogitoProcessInstancesMultiEventsPath, platform),
 		d.newTrigger(lbl, brokerName, namespace, serviceName, "jobs", "JobEvent", constants.KogitoJobsPath, platform)}, nil
 }
 

--- a/internal/controller/profiles/common/constants/platform_services.go
+++ b/internal/controller/profiles/common/constants/platform_services.go
@@ -38,11 +38,13 @@ const (
 	JobServiceLeaderCheckExpirationInSeconds        = "kogito.jobs-service.management.leader-check.expiration-in-seconds"
 	DefaultJobServiceLeaderCheckExpirationInSeconds = "60"
 
-	KogitoProcessInstancesEventsConnector       = "mp.messaging.outgoing.kogito-processinstances-events.connector"
-	KogitoProcessInstancesEventsMethod          = "mp.messaging.outgoing.kogito-processinstances-events.method"
-	KogitoProcessInstancesEventsURL             = "mp.messaging.outgoing.kogito-processinstances-events.url"
-	KogitoProcessInstancesEventsEnabled         = "kogito.events.processinstances.enabled"
-	KogitoProcessInstancesEventsPath            = "/processes"
+	KogitoProcessInstancesEventsConnector = "mp.messaging.outgoing.kogito-processinstances-events.connector"
+	KogitoProcessInstancesEventsMethod    = "mp.messaging.outgoing.kogito-processinstances-events.method"
+	KogitoProcessInstancesEventsURL       = "mp.messaging.outgoing.kogito-processinstances-events.url"
+	KogitoProcessInstancesEventsEnabled   = "kogito.events.processinstances.enabled"
+	KogitoProcessInstancesEventsPath      = "/processes"
+	// KogitoProcessInstancesMultiEventsPath Same value as KogitoProcessInstancesEventsPath intentionally
+	KogitoProcessInstancesMultiEventsPath       = "/processes"
 	KogitoProcessDefinitionsEventsConnector     = "mp.messaging.outgoing.kogito-processdefinitions-events.connector"
 	KogitoProcessDefinitionsEventsMethod        = "mp.messaging.outgoing.kogito-processdefinitions-events.method"
 	KogitoProcessDefinitionsEventsURL           = "mp.messaging.outgoing.kogito-processdefinitions-events.url"

--- a/internal/controller/profiles/common/constants/workflows.go
+++ b/internal/controller/profiles/common/constants/workflows.go
@@ -29,4 +29,5 @@ const (
 	QuarkusDevUICorsEnabled                  = "quarkus.dev-ui.cors.enabled"
 	QuarkusHttpCors                          = "quarkus.http.cors"
 	QuarkusHttpCorsOrigins                   = "quarkus.http.cors.origins"
+	KogitoEventsGrouping                     = "kogito.events.grouping"
 )

--- a/internal/controller/profiles/common/properties/managed.go
+++ b/internal/controller/profiles/common/properties/managed.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/apache/incubator-kie-kogito-serverless-operator/internal/controller/cfg"
+
 	"github.com/apache/incubator-kie-kogito-serverless-operator/internal/controller/profiles"
 
 	"github.com/apache/incubator-kie-kogito-serverless-operator/internal/controller/profiles/common/persistence"
@@ -157,6 +159,7 @@ func NewManagedPropertyHandler(workflow *operatorapi.SonataFlow, platform *opera
 	if profiles.IsDevProfile(workflow) {
 		setDevProfileProperties(props)
 	}
+	setControllersConfigProperties(workflow, props)
 	props.Set(constants.KogitoUserTasksEventsEnabled, "false")
 	if platform != nil {
 		p, err := resolvePlatformWorkflowProperties(platform)
@@ -190,6 +193,12 @@ func NewManagedPropertyHandler(workflow *operatorapi.SonataFlow, platform *opera
 
 	handler.defaultManagedProperties = props
 	return handler.withKogitoServiceUrl(), nil
+}
+
+func setControllersConfigProperties(workflow *operatorapi.SonataFlow, props *properties.Properties) {
+	if !profiles.IsDevProfile(workflow) && cfg.GetCfg().KogitoEventsGrouping {
+		props.Set(constants.KogitoEventsGrouping, "true")
+	}
 }
 
 func setDevProfileProperties(props *properties.Properties) {

--- a/operator.yaml
+++ b/operator.yaml
@@ -28217,7 +28217,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  controllers_cfg.yaml: |
+  controllers_cfg.yaml: |-
     # Licensed to the Apache Software Foundation (ASF) under one
     # or more contributor license agreements.  See the NOTICE file
     # distributed with this work for additional information
@@ -28275,6 +28275,9 @@ data:
       - groupId: org.kie
         artifactId: kie-addons-quarkus-persistence-jdbc
         version: 999-20240912-SNAPSHOT
+    # If true, the workflow deployments will be configured to send accumulated workflow status change events to the Data
+    # Index Service reducing the number of produced events. Set to false to send individual events.
+    kogitoEventsGrouping: true
 kind: ConfigMap
 metadata:
   name: sonataflow-operator-controllers-config


### PR DESCRIPTION

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>