### PR TITLE
[issue-554] Knative trigger validation in E2E test randomly fails

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -265,7 +265,10 @@ func verifyTrigger(triggers []operatorapi.SonataFlowPlatformTriggerRef, namePref
 	GinkgoWriter.Println("Triggers from platform status:", triggers)
 	for _, ref := range triggers {
 		if strings.HasPrefix(ref.Name, namePrefix) && ref.Namespace == ns {
-			return verifyTriggerData(ref.Name, ns, path, broker)
+			EventuallyWithOffset(1, func() error {
+				return verifyTriggerData(ref.Name, ns, path, broker)
+			}, 2*time.Minute, 5).Should(Succeed())
+			return nil
 		}
 	}
 	return fmt.Errorf("failed to find trigger to verify with prefix: %v, namespace: %v", namePrefix, ns)


### PR DESCRIPTION
**Description of the change:**

Fix #554 

Use a loop to retry the trigger data validation. This is because after the trigger gets created, it takes some time for it's status to get ready.

**Motivation for the change:**
Make E2E test more stable.

**Checklist**
- [X] Have you verified that tall the tests are passing?
