### PR TITLE
[DRAFT] kie-kogito-serverless-operator-556: Move the Jobs Service provisioning from k8s Deployment to a StatefulSet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test: manifests generate envtest test-api ## Run tests.
 	@$(MAKE) fmt
 	@echo "🔍 Running controller tests..."
 	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	go test $(shell go list ./... | grep -v /test/) -coverprofile cover.out > /dev/null 2>&1
+	go test $(shell go list ./... | grep -v /test/) -coverprofile cover.out
 	@echo "✅  Tests completed successfully. Coverage report generated: cover.out."
 
 .PHONY: test-api

--- a/config/rbac/builder_role.yaml
+++ b/config/rbac/builder_role.yaml
@@ -35,6 +35,7 @@ rules:
   - secrets
   - events
   - deployments
+  - statefulsets
   - nodes
   verbs:
   - create
@@ -59,6 +60,7 @@ rules:
     - secrets
     - events
     - deployments
+    - statefulsets
     - nodes
   verbs:
     - create

--- a/internal/controller/platform/services/services.go
+++ b/internal/controller/platform/services/services.go
@@ -69,6 +69,8 @@ type PlatformServiceHandler interface {
 	GetPodResourceRequirements() corev1.ResourceRequirements
 	// GetReplicaCount Returns the default pod replica count for the given service
 	GetReplicaCount() int32
+	// GetDeploymentType Returns the deployment type required for the service.
+	GetDeploymentType() constants.DeploymentType
 
 	// MergeContainerSpec performs a merge with override using the containerSpec argument and the expected values based on the service's pod template specifications. The returning
 	// object is the merged result
@@ -254,6 +256,10 @@ func (d *DataIndexHandler) GetReplicaCount() int32 {
 	return 1
 }
 
+func (d *DataIndexHandler) GetDeploymentType() constants.DeploymentType {
+	return constants.Deployment
+}
+
 func (d *DataIndexHandler) GetServiceCmName() string {
 	return fmt.Sprintf("%s-props", d.GetServiceName())
 }
@@ -383,6 +389,10 @@ func (j *JobServiceHandler) GetPodResourceRequirements() corev1.ResourceRequirem
 
 func (j *JobServiceHandler) GetReplicaCount() int32 {
 	return 1
+}
+
+func (j *JobServiceHandler) GetDeploymentType() constants.DeploymentType {
+	return constants.StatefulSet
 }
 
 func (j JobServiceHandler) MergeContainerSpec(containerSpec *corev1.Container) (*corev1.Container, error) {
@@ -705,7 +715,7 @@ func (j *JobServiceHandler) GenerateKnativeResources(platform *operatorapi.Sonat
 						Name:       j.GetServiceName(),
 						Namespace:  platform.Namespace,
 						APIVersion: "apps/v1",
-						Kind:       "Deployment",
+						Kind:       string(j.GetDeploymentType()),
 					},
 				},
 			},

--- a/internal/controller/profiles/common/constants/platform_services.go
+++ b/internal/controller/profiles/common/constants/platform_services.go
@@ -77,6 +77,12 @@ const (
 
 	DefaultDatabaseName   string = "sonataflow"
 	DefaultPostgreSQLPort int    = 5432
+
+	ServiceProbeInitialDelaySeconds int = 45
+	ServiceProbeTimeoutSeconds      int = 10
+	ServiceProbePeriodSeconds       int = 30
+	ServiceProbeSuccessThreshold    int = 1
+	ServiceProbeFailureThreshold    int = 4
 )
 
 type PersistenceType string
@@ -89,3 +95,10 @@ const (
 func (p PersistenceType) String() string {
 	return string(p)
 }
+
+type DeploymentType string
+
+const (
+	Deployment  DeploymentType = "Deployment"
+	StatefulSet DeploymentType = "StatefulSet"
+)

--- a/internal/controller/profiles/common/persistence/postgresql.go
+++ b/internal/controller/profiles/common/persistence/postgresql.go
@@ -34,7 +34,7 @@ const (
 	defaultDatabaseName = "sonataflow"
 )
 
-// ConfigurePostgreSQLEnv returns the common env variables required for the DataIndex or JobsService when postresql persistence is used.
+// ConfigurePostgreSQLEnv returns the common env variables required for the DataIndex or JobsService when postgresql persistence is used.
 func ConfigurePostgreSQLEnv(postgresql *operatorapi.PersistencePostgreSQL, databaseSchema, databaseNamespace string) []corev1.EnvVar {
 	dataSourcePort := constants.DefaultPostgreSQLPort
 	databaseName := defaultDatabaseName

--- a/internal/controller/sonataflowplatform_controller_test.go
+++ b/internal/controller/sonataflowplatform_controller_test.go
@@ -362,14 +362,15 @@ func TestSonataFlowPlatformController(t *testing.T) {
 		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbPassword)
 		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbSourceDIURL)
 
+		stfSet := &appsv1.StatefulSet{}
 		js := services.NewJobServiceHandler(ksp)
-		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, dep))
-		assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
-		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypePostgreSQL), dep.Spec.Template.Spec.Containers[0].Image)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbSourceKind)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbUsername)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbPassword)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbSourceJSURL)
+		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, stfSet))
+		assert.Len(t, stfSet.Spec.Template.Spec.Containers, 1)
+		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypePostgreSQL), stfSet.Spec.Template.Spec.Containers[0].Image)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[0].Env, dbSourceKind)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[0].Env, dbUsername)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[0].Env, dbPassword)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[0].Env, dbSourceJSURL)
 	})
 
 	t.Run("verify that persistence options are correctly reconciled when defined in the platform and overwriten in the services spec", func(t *testing.T) {
@@ -483,14 +484,15 @@ func TestSonataFlowPlatformController(t *testing.T) {
 		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbDIPassword)
 		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "QUARKUS_DATASOURCE_JDBC_URL", Value: urlDI})
 
+		stfSet := &appsv1.StatefulSet{}
 		js := services.NewJobServiceHandler(ksp)
-		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, dep))
-		assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
-		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypePostgreSQL), dep.Spec.Template.Spec.Containers[0].Image)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbSourceKind)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbJSUsername)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, dbJSPassword)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "QUARKUS_DATASOURCE_JDBC_URL", Value: urlJS})
+		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, stfSet))
+		assert.Len(t, stfSet.Spec.Template.Spec.Containers, 1)
+		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypePostgreSQL), stfSet.Spec.Template.Spec.Containers[0].Image)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[0].Env, dbSourceKind)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[0].Env, dbJSUsername)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[0].Env, dbJSPassword)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "QUARKUS_DATASOURCE_JDBC_URL", Value: urlJS})
 	})
 
 	// Job Service tests
@@ -535,15 +537,15 @@ func TestSonataFlowPlatformController(t *testing.T) {
 
 		assert.Equal(t, "", ksp.Status.GetTopLevelCondition().Reason)
 
-		// Check data index deployment
-		dep := &appsv1.Deployment{}
+		// Check jobs service deployment
+		stfSet := &appsv1.StatefulSet{}
 		js := services.NewJobServiceHandler(ksp)
-		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, dep))
+		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, stfSet))
 
-		assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
-		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypeEphemeral), dep.Spec.Template.Spec.Containers[0].Image)
-		assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Env, envDBKind)
-		assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Env, envDataIndex)
+		assert.Len(t, stfSet.Spec.Template.Spec.Containers, 1)
+		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypeEphemeral), stfSet.Spec.Template.Spec.Containers[0].Image)
+		assert.NotContains(t, stfSet.Spec.Template.Spec.Containers[0].Env, envDBKind)
+		assert.NotContains(t, stfSet.Spec.Template.Spec.Containers[0].Env, envDataIndex)
 
 		// Check with persistence set
 		ksp.Spec.Services.JobService.Persistence = &v1alpha08.PersistenceOptionsSpec{PostgreSQL: &v1alpha08.PersistencePostgreSQL{
@@ -560,15 +562,15 @@ func TestSonataFlowPlatformController(t *testing.T) {
 			t.Fatalf("reconcile: (%v)", err)
 		}
 
-		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, dep))
-		assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
-		assert.Equal(t, constants.JobServiceName+"2", dep.Spec.Template.Spec.Containers[0].Name)
-		assert.Equal(t, "testing", dep.Spec.Template.Spec.Containers[0].TerminationMessagePath)
-		assert.Equal(t, constants.JobServiceName, dep.Spec.Template.Spec.Containers[1].Name)
-		assert.Equal(t, "testing", dep.Spec.Template.Spec.Containers[1].TerminationMessagePath)
-		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypePostgreSQL), dep.Spec.Template.Spec.Containers[1].Image)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Env, envDBKind)
-		assert.NotContains(t, dep.Spec.Template.Spec.Containers[1].Env, envDataIndex)
+		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, stfSet))
+		assert.Len(t, stfSet.Spec.Template.Spec.Containers, 2)
+		assert.Equal(t, constants.JobServiceName+"2", stfSet.Spec.Template.Spec.Containers[0].Name)
+		assert.Equal(t, "testing", stfSet.Spec.Template.Spec.Containers[0].TerminationMessagePath)
+		assert.Equal(t, constants.JobServiceName, stfSet.Spec.Template.Spec.Containers[1].Name)
+		assert.Equal(t, "testing", stfSet.Spec.Template.Spec.Containers[1].TerminationMessagePath)
+		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypePostgreSQL), stfSet.Spec.Template.Spec.Containers[1].Image)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[1].Env, envDBKind)
+		assert.NotContains(t, stfSet.Spec.Template.Spec.Containers[1].Env, envDataIndex)
 	})
 
 	t.Run("verify that a basic reconcile with job service & jdbcUrl is performed without error", func(t *testing.T) {
@@ -622,14 +624,14 @@ func TestSonataFlowPlatformController(t *testing.T) {
 
 		assert.Equal(t, "", ksp.Status.GetTopLevelCondition().Reason)
 
-		// Check job service deployment
-		dep := &appsv1.Deployment{}
-		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, dep))
+		// Check job service statefulset
+		stfSet := &appsv1.StatefulSet{}
+		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, stfSet))
 
-		assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
-		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypeEphemeral), dep.Spec.Template.Spec.Containers[0].Image)
-		assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Env, envDBKind)
-		assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Env, envDataIndex)
+		assert.Len(t, stfSet.Spec.Template.Spec.Containers, 1)
+		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypeEphemeral), stfSet.Spec.Template.Spec.Containers[0].Image)
+		assert.NotContains(t, stfSet.Spec.Template.Spec.Containers[0].Env, envDBKind)
+		assert.NotContains(t, stfSet.Spec.Template.Spec.Containers[0].Env, envDataIndex)
 
 		// Check with persistence set
 		url := "jdbc:postgresql://host:1234/database?currentSchema=data-index-service"
@@ -646,13 +648,13 @@ func TestSonataFlowPlatformController(t *testing.T) {
 			t.Fatalf("reconcile: (%v)", err)
 		}
 
-		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, dep))
-		assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
-		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypePostgreSQL), dep.Spec.Template.Spec.Containers[0].Image)
-		assert.Equal(t, int32(1), *dep.Spec.Replicas)
-		assert.Equal(t, []string{"test:latest"}, dep.Spec.Template.Spec.Containers[0].Command)
-		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, envDBKind)
-		assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Env, envDataIndex)
+		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, stfSet))
+		assert.Len(t, stfSet.Spec.Template.Spec.Containers, 1)
+		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypePostgreSQL), stfSet.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, int32(1), *stfSet.Spec.Replicas)
+		assert.Equal(t, []string{"test:latest"}, stfSet.Spec.Template.Spec.Containers[0].Command)
+		assert.Contains(t, stfSet.Spec.Template.Spec.Containers[0].Env, envDBKind)
+		assert.NotContains(t, stfSet.Spec.Template.Spec.Containers[0].Env, envDataIndex)
 	})
 
 	t.Run("verify that a default deployment of a job and data index service will is performed without error", func(t *testing.T) {
@@ -710,14 +712,14 @@ func TestSonataFlowPlatformController(t *testing.T) {
 		assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Env, envDBKind)
 		assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, envDataIndex)
 
-		// Check job service deployment
-		dep = &appsv1.Deployment{}
-		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, dep))
+		// Check job service statefulset
+		stfSet := &appsv1.StatefulSet{}
+		assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: js.GetServiceName(), Namespace: ksp.Namespace}, stfSet))
 
-		assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
-		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypeEphemeral), dep.Spec.Template.Spec.Containers[0].Image)
-		assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Env, envDBKind)
-		assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Env, envDataIndex)
+		assert.Len(t, stfSet.Spec.Template.Spec.Containers, 1)
+		assert.Equal(t, js.GetServiceImageName(constants.PersistenceTypeEphemeral), stfSet.Spec.Template.Spec.Containers[0].Image)
+		assert.NotContains(t, stfSet.Spec.Template.Spec.Containers[0].Env, envDBKind)
+		assert.NotContains(t, stfSet.Spec.Template.Spec.Containers[0].Env, envDataIndex)
 
 	})
 	t.Run("verify that a basic reconcile of a cluster platform is performed without error", func(t *testing.T) {

--- a/operator.yaml
+++ b/operator.yaml
@@ -27602,6 +27602,7 @@ rules:
   - secrets
   - events
   - deployments
+  - statefulsets
   - nodes
   verbs:
   - create
@@ -27626,6 +27627,7 @@ rules:
   - secrets
   - events
   - deployments
+  - statefulsets
   - nodes
   verbs:
   - create


### PR DESCRIPTION

<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>