### PR TITLE
kie-kogito-serverless-operator-566: Make the operator configure the binary and compress properties for the kogito events grouping in preview and gitops workflow deployments

### DIFF
--- a/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
+++ b/bundle/manifests/sonataflow-operator-controllers-config_v1_configmap.yaml
@@ -61,6 +61,11 @@ data:
     # If true, the workflow deployments will be configured to send accumulated workflow status change events to the Data
     # Index Service reducing the number of produced events. Set to false to send individual events.
     kogitoEventsGrouping: true
+    # If true, the accumulated workflow status change events will be sent in binary mode. (reduces the evens size)
+    kogitoEventsGroupingBinary: true
+    # If true, the accumulated workflow status change events, when sent in binary mode, will be gzipped at the cost of
+    # some performance.
+    kogitoEventsGroupingCompress: false
 kind: ConfigMap
 metadata:
   name: sonataflow-operator-controllers-config

--- a/config/manager/controllers_cfg.yaml
+++ b/config/manager/controllers_cfg.yaml
@@ -58,3 +58,8 @@ postgreSQLPersistenceExtensions:
 # If true, the workflow deployments will be configured to send accumulated workflow status change events to the Data
 # Index Service reducing the number of produced events. Set to false to send individual events.
 kogitoEventsGrouping: true
+# If true, the accumulated workflow status change events will be sent in binary mode. (reduces the evens size)
+kogitoEventsGroupingBinary: true
+# If true, the accumulated workflow status change events, when sent in binary mode, will be gzipped at the cost of
+# some performance.
+kogitoEventsGroupingCompress: false

--- a/internal/controller/cfg/controllers_cfg.go
+++ b/internal/controller/cfg/controllers_cfg.go
@@ -72,6 +72,8 @@ type ControllersCfg struct {
 	BuilderConfigMapName            string `yaml:"builderConfigMapName,omitempty"`
 	PostgreSQLPersistenceExtensions []GAV  `yaml:"postgreSQLPersistenceExtensions,omitempty"`
 	KogitoEventsGrouping            bool   `yaml:"kogitoEventsGrouping,omitempty"`
+	KogitoEventsGroupingBinary      bool   `yaml:"KogitoEventsGroupingBinary,omitempty"`
+	KogitoEventsGroupingCompress    bool   `yaml:"KogitoEventsGroupingCompress,omitempty"`
 }
 
 // InitializeControllersCfg initializes the platform configuration for this instance.

--- a/internal/controller/cfg/controllers_cfg_test.go
+++ b/internal/controller/cfg/controllers_cfg_test.go
@@ -55,6 +55,8 @@ func TestInitializeControllersCfgAt_ValidFile(t *testing.T) {
 		Version:    "999-SNAPSHOT",
 	}, postgresExtensions[2])
 	assert.True(t, cfg.KogitoEventsGrouping)
+	assert.True(t, cfg.KogitoEventsGroupingBinary)
+	assert.False(t, cfg.KogitoEventsGroupingCompress)
 }
 
 func TestInitializeControllersCfgAt_FileNotFound(t *testing.T) {

--- a/internal/controller/cfg/testdata/controllers-cfg-test.yaml
+++ b/internal/controller/cfg/testdata/controllers-cfg-test.yaml
@@ -36,3 +36,5 @@ postgreSQLPersistenceExtensions:
     artifactId: kie-addons-quarkus-persistence-jdbc
     version: 999-SNAPSHOT
 kogitoEventsGrouping: true
+kogitoEventsGroupingBinary: true
+kogitoEventsGroupingCompress: false

--- a/internal/controller/profiles/common/constants/workflows.go
+++ b/internal/controller/profiles/common/constants/workflows.go
@@ -30,4 +30,6 @@ const (
 	QuarkusHttpCors                          = "quarkus.http.cors"
 	QuarkusHttpCorsOrigins                   = "quarkus.http.cors.origins"
 	KogitoEventsGrouping                     = "kogito.events.grouping"
+	KogitoEventsGroupingBinary               = "kogito.events.grouping.binary"
+	KogitoEventsGroupingCompress             = "kogito.events.grouping.compress"
 )

--- a/internal/controller/profiles/common/properties/managed.go
+++ b/internal/controller/profiles/common/properties/managed.go
@@ -198,6 +198,12 @@ func NewManagedPropertyHandler(workflow *operatorapi.SonataFlow, platform *opera
 func setControllersConfigProperties(workflow *operatorapi.SonataFlow, props *properties.Properties) {
 	if !profiles.IsDevProfile(workflow) && cfg.GetCfg().KogitoEventsGrouping {
 		props.Set(constants.KogitoEventsGrouping, "true")
+		if cfg.GetCfg().KogitoEventsGroupingBinary {
+			props.Set(constants.KogitoEventsGroupingBinary, "true")
+			if cfg.GetCfg().KogitoEventsGroupingCompress {
+				props.Set(constants.KogitoEventsGroupingCompress, "true")
+			}
+		}
 	}
 }
 

--- a/operator.yaml
+++ b/operator.yaml
@@ -28155,6 +28155,11 @@ data:
     # If true, the workflow deployments will be configured to send accumulated workflow status change events to the Data
     # Index Service reducing the number of produced events. Set to false to send individual events.
     kogitoEventsGrouping: true
+    # If true, the accumulated workflow status change events will be sent in binary mode. (reduces the evens size)
+    kogitoEventsGroupingBinary: true
+    # If true, the accumulated workflow status change events, when sent in binary mode, will be gzipped at the cost of
+    # some performance.
+    kogitoEventsGroupingCompress: false
 kind: ConfigMap
 metadata:
   name: sonataflow-operator-controllers-config


### PR DESCRIPTION
Closes: #566 
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>