### PR TITLE
kie-kogito-serverless-operator-568: Disable Workflows DI and JS availability health checks when Knative Eventing is configured

### DIFF
--- a/internal/controller/platform/services/properties.go
+++ b/internal/controller/platform/services/properties.go
@@ -24,13 +24,14 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/apache/incubator-kie-kogito-serverless-operator/internal/controller/workflowdef"
+
 	"k8s.io/klog/v2"
 
 	operatorapi "github.com/apache/incubator-kie-kogito-serverless-operator/api/v1alpha08"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/internal/controller/knative"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/internal/controller/profiles"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/internal/controller/profiles/common/constants"
-	"github.com/apache/incubator-kie-kogito-serverless-operator/internal/controller/workflowdef"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/log"
 	"github.com/apache/incubator-kie-kogito-serverless-operator/utils"
 
@@ -173,8 +174,6 @@ func GenerateDataIndexWorkflowProperties(workflow *operatorapi.SonataFlow, platf
 			props.Set(constants.KogitoProcessDefinitionsEventsEnabled, "true")
 			props.Set(constants.KogitoProcessInstancesEventsEnabled, "true")
 			props.Set(constants.KogitoProcessDefinitionsEventsErrorsEnabled, "true")
-			props.Set(constants.KogitoDataIndexHealthCheckEnabled, "true")
-			props.Set(constants.KogitoDataIndexURL, serviceBaseUrl)
 			if sink != nil {
 				props.Set(constants.KogitoProcessDefinitionsEventsConnector, constants.QuarkusHTTP)
 				props.Set(constants.KogitoProcessInstancesEventsConnector, constants.QuarkusHTTP)
@@ -183,6 +182,8 @@ func GenerateDataIndexWorkflowProperties(workflow *operatorapi.SonataFlow, platf
 				props.Set(constants.KogitoProcessDefinitionsEventsMethod, constants.Post)
 				props.Set(constants.KogitoProcessInstancesEventsMethod, constants.Post)
 			} else {
+				props.Set(constants.KogitoDataIndexHealthCheckEnabled, "true")
+				props.Set(constants.KogitoDataIndexURL, serviceBaseUrl)
 				props.Set(constants.KogitoProcessDefinitionsEventsURL, serviceBaseUrl+constants.KogitoProcessDefinitionsEventsPath)
 				props.Set(constants.KogitoProcessInstancesEventsURL, serviceBaseUrl+constants.KogitoProcessInstancesEventsPath)
 			}
@@ -209,15 +210,15 @@ func GenerateJobServiceWorkflowProperties(workflow *operatorapi.SonataFlow, plat
 	if !profiles.IsDevProfile(workflow) && workflow != nil && workflow.Status.Services != nil && workflow.Status.Services.JobServiceRef != nil {
 		serviceBaseUrl := workflow.Status.Services.JobServiceRef.Url
 		if js.IsServiceEnabled() && len(serviceBaseUrl) > 0 {
-			if workflowdef.HasTimeouts(workflow) {
-				props.Set(constants.KogitoJobServiceHealthCheckEnabled, "true")
-			}
-			props.Set(constants.KogitoJobServiceURL, serviceBaseUrl)
 			if sink != nil {
 				props.Set(constants.JobServiceRequestEventsURL, constants.KnativeInjectedEnvVar)
 				props.Set(constants.JobServiceRequestEventsConnector, constants.QuarkusHTTP)
 				props.Set(constants.JobServiceRequestEventsMethod, constants.Post)
 			} else {
+				if workflowdef.HasTimeouts(workflow) {
+					props.Set(constants.KogitoJobServiceHealthCheckEnabled, "true")
+				}
+				props.Set(constants.KogitoJobServiceURL, serviceBaseUrl)
 				props.Set(constants.JobServiceRequestEventsURL, serviceBaseUrl+constants.JobServiceJobEventsPath)
 			}
 		}


### PR DESCRIPTION
Closes: #568 
<!--

Welcome to the SonataFlow Operator! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concise and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [X] Add or Modify a unit test for your change
- [X] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>